### PR TITLE
Add gas estimate offset

### DIFF
--- a/src/domain/dex/mod.rs
+++ b/src/domain/dex/mod.rs
@@ -110,18 +110,12 @@ impl Swap {
         risk: &domain::Risk,
         simulator: &infra::dex::Simulator,
     ) -> Option<solution::Solution> {
-        let gas = if order.class == order::Class::Limit {
-            match simulator.gas(order.owner(), &self).await {
-                Ok(value) => value,
-                Err(err) => {
-                    tracing::warn!(?err, "gas simulation failed");
-                    return None;
-                }
+        let gas = match simulator.gas(order.owner(), &self).await {
+            Ok(value) => value,
+            Err(err) => {
+                tracing::warn!(?err, "gas simulation failed");
+                return None;
             }
-        } else {
-            // We are fine with just using heuristic gas for market orders,
-            // since it doesn't really play a role in the final solution.
-            self.gas
         };
         let score = solution::Score::RiskAdjusted(solution::SuccessProbability(
             risk.success_probability(gas, gas_price, 1),

--- a/src/domain/eth/mod.rs
+++ b/src/domain/eth/mod.rs
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn add_gas_offset() {
         let gas = |value: u128| Gas(value.into());
-        let offset = |value| SignedGas::from(value);
+        let offset = SignedGas::from;
 
         // saturating sub
         assert_eq!(gas(100) + offset(-101), gas(0));

--- a/src/domain/eth/mod.rs
+++ b/src/domain/eth/mod.rs
@@ -45,6 +45,18 @@ impl From<U256> for Ether {
     }
 }
 
+impl std::ops::Add<SignedGas> for Gas {
+    type Output = Self;
+
+    fn add(self, rhs: SignedGas) -> Self::Output {
+        if rhs.is_positive {
+            Self(self.0.saturating_add(rhs.amount))
+        } else {
+            Self(self.0.saturating_sub(rhs.amount))
+        }
+    }
+}
+
 /// Gas amount.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Gas(pub U256);
@@ -54,6 +66,22 @@ impl std::ops::Add for Gas {
 
     fn add(self, rhs: Self) -> Self::Output {
         Self(self.0 + rhs.0)
+    }
+}
+
+/// Like [`Gas`] but can be negative to encode a gas discount.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct SignedGas {
+    is_positive: bool,
+    amount: U256,
+}
+
+impl From<i64> for SignedGas {
+    fn from(value: i64) -> Self {
+        Self {
+            is_positive: value.is_positive(),
+            amount: value.abs().into(),
+        }
     }
 }
 

--- a/src/domain/eth/mod.rs
+++ b/src/domain/eth/mod.rs
@@ -49,10 +49,10 @@ impl std::ops::Add<SignedGas> for Gas {
     type Output = Self;
 
     fn add(self, rhs: SignedGas) -> Self::Output {
-        if rhs.is_positive {
-            Self(self.0.saturating_add(rhs.amount))
+        if rhs.0.is_positive() {
+            Self(self.0.saturating_add(rhs.0.into()))
         } else {
-            Self(self.0.saturating_sub(rhs.amount))
+            Self(self.0.saturating_sub(rhs.0.abs().into()))
         }
     }
 }
@@ -71,17 +71,11 @@ impl std::ops::Add for Gas {
 
 /// Like [`Gas`] but can be negative to encode a gas discount.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct SignedGas {
-    is_positive: bool,
-    amount: U256,
-}
+pub struct SignedGas(i64);
 
 impl From<i64> for SignedGas {
     fn from(value: i64) -> Self {
-        Self {
-            is_positive: value.is_positive(),
-            amount: value.abs().into(),
-        }
+        Self(value)
     }
 }
 

--- a/src/domain/eth/mod.rs
+++ b/src/domain/eth/mod.rs
@@ -58,7 +58,7 @@ impl std::ops::Add<SignedGas> for Gas {
 }
 
 /// Gas amount.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Gas(pub U256);
 
 impl std::ops::Add for Gas {
@@ -106,4 +106,27 @@ pub struct Tx {
     pub value: Ether,
     pub input: Bytes<Vec<u8>>,
     pub access_list: AccessList,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_gas_offset() {
+        let gas = |value: u128| Gas(value.into());
+        let offset = |value| SignedGas::from(value);
+
+        // saturating sub
+        assert_eq!(gas(100) + offset(-101), gas(0));
+
+        // regular sub
+        assert_eq!(gas(100) + offset(-90), gas(10));
+
+        // saturating add
+        assert_eq!(Gas(U256::MAX) + offset(100), Gas(U256::MAX));
+
+        // regular add
+        assert_eq!(gas(100) + offset(100), gas(200));
+    }
 }

--- a/src/domain/order.rs
+++ b/src/domain/order.rs
@@ -36,7 +36,7 @@ impl Order {
 
     /// Returns `true` if the order expects a solver-computed fee.
     pub fn solver_determines_fee(&self) -> bool {
-        self.class == Class::Limit
+        self.class != Class::Liquidity && self.fee.0.is_zero()
     }
 }
 

--- a/src/domain/solution.rs
+++ b/src/domain/solution.rs
@@ -129,14 +129,13 @@ pub struct Single {
     pub output: eth::Asset,
     /// The swap interactions for the single order settlement.
     pub interactions: Vec<Interaction>,
-    /// The estimated gas needed for swapping the sell amount to buy amount.
+    /// The estimated gas needed for swapping the sell amount to buy amount
+    /// already including the additional overhead of calling the settlement
+    /// contract.
     pub gas: eth::Gas,
 }
 
 impl Single {
-    /// An approximation for the overhead of executing a trade in a settlement.
-    const SETTLEMENT_OVERHEAD: u64 = 106_391;
-
     /// Creates a full solution for a single order solution given gas and sell
     /// token prices.
     pub fn into_solution(
@@ -163,13 +162,7 @@ impl Single {
             // full order fee as well as a solver computed fee. Note that this
             // is fine for now, since there is no way to create limit orders
             // with non-zero fees.
-            Fee::Surplus(
-                sell_token?.ether_value(eth::Ether(
-                    swap.0
-                        .checked_add(Self::SETTLEMENT_OVERHEAD.into())?
-                        .checked_mul(gas_price.0 .0)?,
-                ))?,
-            )
+            Fee::Surplus(sell_token?.ether_value(eth::Ether(swap.0.checked_mul(gas_price.0 .0)?))?)
         } else {
             Fee::Protocol
         };
@@ -218,7 +211,7 @@ impl Single {
             trades: vec![Trade::Fulfillment(Fulfillment::new(order, executed, fee)?)],
             interactions,
             score,
-            gas: Some(eth::Gas(Self::SETTLEMENT_OVERHEAD.into()) + self.gas),
+            gas: Some(self.gas),
         })
     }
 }

--- a/src/domain/solver/dex/mod.rs
+++ b/src/domain/solver/dex/mod.rs
@@ -58,6 +58,7 @@ impl Dex {
                 &config.node_url,
                 config.contracts.settlement,
                 config.contracts.authenticator,
+                config.solution_gas_offset,
             ),
             slippage: config.slippage,
             concurrent_requests: config.concurrent_requests,

--- a/src/infra/config/dex/file.rs
+++ b/src/infra/config/dex/file.rs
@@ -61,9 +61,8 @@ struct Config {
     #[serde(with = "humantime_serde", default = "default_max_back_off")]
     max_back_off: Duration,
 
-    /// Offset applied to the gas estimate for a solution to hackily address
-    /// systematic over- or under-estimation of the execution cost of orders.
-    /// To be configured in units of gas.
+    /// Units of gas that get added to the gas estimate for executing a
+    /// computed trade route to arrive at a gas estimate for a whole settlement.
     #[serde(default)]
     solution_gas_offset: i64,
 

--- a/src/infra/config/dex/file.rs
+++ b/src/infra/config/dex/file.rs
@@ -61,6 +61,12 @@ struct Config {
     #[serde(with = "humantime_serde", default = "default_max_back_off")]
     max_back_off: Duration,
 
+    /// Offset applied to the gas estimate for a solution to hackily address
+    /// systematic over- or under-estimation of the execution cost of orders.
+    /// To be configured in units of gas.
+    #[serde(default)]
+    solution_gas_offset: i64,
+
     /// Settings specific to the wrapped dex API.
     dex: toml::Value,
 }
@@ -148,6 +154,7 @@ pub async fn load<T: DeserializeOwned>(path: &Path) -> (super::Config, T) {
             config.max_back_off,
         )
         .unwrap(),
+        solution_gas_offset: config.solution_gas_offset.into(),
     };
     (config, dex)
 }

--- a/src/infra/config/dex/mod.rs
+++ b/src/infra/config/dex/mod.rs
@@ -27,4 +27,5 @@ pub struct Config {
     pub smallest_partial_fill: eth::Ether,
     pub risk: Risk,
     pub rate_limiting_strategy: RateLimitingStrategy,
+    pub solution_gas_offset: eth::SignedGas,
 }

--- a/src/infra/dex/simulator.rs
+++ b/src/infra/dex/simulator.rs
@@ -15,6 +15,9 @@ pub struct Simulator {
     web3: ethrpc::Web3,
     settlement: eth::ContractAddress,
     authenticator: eth::ContractAddress,
+    /// Configurable offset to adjust for systematic under- or
+    /// over-estimating of gas costs.
+    gas_offset: eth::SignedGas,
 }
 
 impl Simulator {
@@ -23,11 +26,13 @@ impl Simulator {
         url: &reqwest::Url,
         settlement: eth::ContractAddress,
         authenticator: eth::ContractAddress,
+        gas_offset: eth::SignedGas,
     ) -> Self {
         Self {
             web3: blockchain::rpc(url),
             settlement,
             authenticator,
+            gas_offset,
         }
     }
 
@@ -107,9 +112,9 @@ impl Simulator {
                 "could not simulate dex swap to get gas used; fall back to gas estimate provided \
                  by dex API"
             );
-            swap.gas
+            swap.gas + self.gas_offset
         } else {
-            eth::Gas(gas)
+            eth::Gas(gas) + self.gas_offset
         })
     }
 }

--- a/src/tests/balancer/market_order.rs
+++ b/src/tests/balancer/market_order.rs
@@ -44,7 +44,12 @@ async fn sell() {
     }])
     .await;
 
-    let engine = tests::SolverEngine::new("balancer", balancer::config(&api.address)).await;
+    let node = tests::mock::node::constant_gas_estimate(195283).await;
+    let engine = tests::SolverEngine::new(
+        "balancer",
+        balancer::config_with_node(&api.address, &node.address),
+    )
+    .await;
 
     let solution = engine
         .solve(json!({
@@ -203,7 +208,12 @@ async fn buy() {
     }])
     .await;
 
-    let engine = tests::SolverEngine::new("balancer", balancer::config(&api.address)).await;
+    let node = tests::mock::node::constant_gas_estimate(195283).await;
+    let engine = tests::SolverEngine::new(
+        "balancer",
+        balancer::config_with_node(&api.address, &node.address),
+    )
+    .await;
 
     let solution = engine
         .solve(json!({

--- a/src/tests/balancer/mod.rs
+++ b/src/tests/balancer/mod.rs
@@ -15,3 +15,16 @@ endpoint = 'http://{solver_addr}/sor'
         ",
     ))
 }
+
+/// Creates a temporary file containing the config of the given solver and a
+/// node.
+pub fn config_with_node(solver_addr: &SocketAddr, node: &SocketAddr) -> tests::Config {
+    tests::Config::String(format!(
+        r"
+node-url = 'http://{node}'
+risk-parameters = [0,0,0,0]
+[dex]
+endpoint = 'http://{solver_addr}/sor'
+        ",
+    ))
+}

--- a/src/tests/dex/partial_fill.rs
+++ b/src/tests/dex/partial_fill.rs
@@ -122,18 +122,7 @@ async fn tested_amounts_adjust_depending_on_response() {
     ])
     .await;
 
-    let simulation_node = mock::http::setup(vec![mock::http::Expectation::Post {
-        path: mock::http::Path::Any,
-        req: mock::http::RequestBody::Any,
-        res: {
-            json!({
-                "id": 1,
-                "jsonrpc": "2.0",
-                "result": "0x0000000000000000000000000000000000000000000000000000000000015B3C"
-            })
-        },
-    }])
-    .await;
+    let simulation_node = mock::node::constant_gas_estimate(195283).await;
 
     let config = tests::Config::String(format!(
         r"
@@ -469,23 +458,7 @@ async fn moves_surplus_fee_to_buy_token() {
     ])
     .await;
 
-    let simulation_node = mock::http::setup(vec![mock::http::Expectation::Post {
-        path: mock::http::Path::Any,
-        req: mock::http::RequestBody::Any,
-        res: {
-            json!({
-                "id": 1,
-                "jsonrpc": "2.0",
-                // If the simulation logic returns 0 it means that the user did not have the
-                // required balance. This could be caused by a pre-interaction that acquires the
-                // necessary sell_token before the trade which is currently not supported by the
-                // simulation loic.
-                // In that case we fall back to the heuristic gas price we had in the past.
-                "result": "0x0000000000000000000000000000000000000000000000000000000000000000"
-            })
-        },
-    }])
-    .await;
+    let simulation_node = mock::node::constant_gas_estimate(195283).await;
 
     let config = tests::Config::String(format!(
         r"
@@ -775,7 +748,12 @@ async fn market() {
     }])
     .await;
 
-    let engine = tests::SolverEngine::new("balancer", balancer::config(&api.address)).await;
+    let node = mock::node::constant_gas_estimate(195283).await;
+    let engine = tests::SolverEngine::new(
+        "balancer",
+        balancer::config_with_node(&api.address, &node.address),
+    )
+    .await;
 
     let solution = engine
         .solve(json!({

--- a/src/tests/mock/mod.rs
+++ b/src/tests/mock/mod.rs
@@ -1,1 +1,2 @@
 pub mod http;
+pub mod node;

--- a/src/tests/mock/node.rs
+++ b/src/tests/mock/node.rs
@@ -1,0 +1,19 @@
+use crate::{
+    domain::eth,
+    tests::mock::http::{setup, Expectation, Path, RequestBody, ServerHandle},
+};
+
+/// Returns a node that will always return the given number as a U256
+/// which will internally be used as a gas estimate for the proposed
+/// solution.
+pub async fn constant_gas_estimate(gas: u64) -> ServerHandle {
+    setup(vec![Expectation::Post {
+        path: Path::Any,
+        req: RequestBody::Any,
+        res: serde_json::json!({
+            "result": format!("{:#066X}", eth::U256::from(gas)),
+            "id": 0,
+        }),
+    }])
+    .await
+}

--- a/src/tests/oneinch/market_order.rs
+++ b/src/tests/oneinch/market_order.rs
@@ -119,7 +119,12 @@ async fn sell() {
     ])
         .await;
 
-    let engine = tests::SolverEngine::new("oneinch", super::config(&api.address)).await;
+    let node = tests::mock::node::constant_gas_estimate(206391).await;
+    let engine = tests::SolverEngine::new(
+        "oneinch",
+        super::config_with_node(&api.address, &node.address),
+    )
+    .await;
 
     let solution = engine
         .solve(json!({

--- a/src/tests/oneinch/mod.rs
+++ b/src/tests/oneinch/mod.rs
@@ -17,3 +17,17 @@ exclude-liquidity = ['UNISWAP_V3', 'PMM4']
         ",
     ))
 }
+
+/// Creates a temporary file containing the config of the given solver and node.
+pub fn config_with_node(solver_addr: &SocketAddr, node: &SocketAddr) -> tests::Config {
+    tests::Config::String(format!(
+        r"
+node-url = 'http://{node}'
+risk-parameters = [0,0,0,0]
+[dex]
+chain-id = '1'
+endpoint = 'http://{solver_addr}'
+exclude-liquidity = ['UNISWAP_V3', 'PMM4']
+        ",
+    ))
+}

--- a/src/tests/paraswap/market_order.rs
+++ b/src/tests/paraswap/market_order.rs
@@ -148,7 +148,12 @@ async fn sell() {
     ])
         .await;
 
-    let engine = tests::SolverEngine::new("paraswap", paraswap::config(&api.address)).await;
+    let node = tests::mock::node::constant_gas_estimate(348691).await;
+    let engine = tests::SolverEngine::new(
+        "paraswap",
+        paraswap::config_with_node(&api.address, &node.address),
+    )
+    .await;
 
     let solution = engine
         .solve(json!({
@@ -404,7 +409,12 @@ async fn buy() {
     ])
         .await;
 
-    let engine = tests::SolverEngine::new("paraswap", paraswap::config(&api.address)).await;
+    let node = tests::mock::node::constant_gas_estimate(213326).await;
+    let engine = tests::SolverEngine::new(
+        "paraswap",
+        paraswap::config_with_node(&api.address, &node.address),
+    )
+    .await;
 
     let solution = engine
         .solve(json!({

--- a/src/tests/paraswap/mod.rs
+++ b/src/tests/paraswap/mod.rs
@@ -18,3 +18,18 @@ partner = 'cow'
         ",
     ))
 }
+
+/// Creates a temporary file containing the config of the given solver and node.
+pub fn config_with_node(solver_addr: &SocketAddr, node: &SocketAddr) -> tests::Config {
+    tests::Config::String(format!(
+        r"
+node-url = 'http://{node}'
+risk-parameters = [0,0,0,0]
+[dex]
+endpoint = 'http://{solver_addr}'
+exclude-dexs = ['UniswapV2']
+address = '0xE0B3700e0aadcb18ed8d4BFF648Bc99896a18ad1'
+partner = 'cow'
+        ",
+    ))
+}

--- a/src/tests/zeroex/market_order.rs
+++ b/src/tests/zeroex/market_order.rs
@@ -88,7 +88,12 @@ async fn sell() {
     }])
         .await;
 
-    let engine = tests::SolverEngine::new("zeroex", zeroex::config(&api.address)).await;
+    let node = mock::node::constant_gas_estimate(234277).await;
+    let engine = tests::SolverEngine::new(
+        "zeroex",
+        zeroex::config_with_node(&api.address, &node.address),
+    )
+    .await;
 
     let solution = engine
         .solve(json!({
@@ -271,7 +276,12 @@ async fn buy() {
     }])
     .await;
 
-    let engine = tests::SolverEngine::new("zeroex", zeroex::config(&api.address)).await;
+    let node = mock::node::constant_gas_estimate(217391).await;
+    let engine = tests::SolverEngine::new(
+        "zeroex",
+        zeroex::config_with_node(&api.address, &node.address),
+    )
+    .await;
 
     let solution = engine
         .solve(json!({

--- a/src/tests/zeroex/mod.rs
+++ b/src/tests/zeroex/mod.rs
@@ -5,7 +5,22 @@ mod not_found;
 mod options;
 mod out_of_price;
 
+/// Creates a temporary file containing the config of the given solver and node.
+pub fn config_with_node(solver_addr: &SocketAddr, node: &SocketAddr) -> tests::Config {
+    tests::Config::String(format!(
+        r"
+node-url = 'http://{node}'
+risk-parameters = [0,0,0,0]
+[dex]
+endpoint = 'http://{solver_addr}/swap/v1/'
+api-key = 'SUPER_SECRET_API_KEY'
+        ",
+    ))
+}
+
 /// Creates a temporary file containing the config of the given solver.
+/// Does not have access to a node so only suitable for tests that not rely on
+/// that.
 pub fn config(solver_addr: &SocketAddr) -> tests::Config {
     tests::Config::String(format!(
         r"

--- a/src/tests/zeroex/options.rs
+++ b/src/tests/zeroex/options.rs
@@ -180,9 +180,10 @@ async fn test() {
     }])
         .await;
 
+    let node = mock::node::constant_gas_estimate(234277).await;
     let config = tests::Config::String(format!(
         r"
-node-url = 'http://localhost:8545'
+node-url = 'http://{}'
 relative-slippage = '0.1'
 risk-parameters = [0,0,0,0]
 [dex]
@@ -193,7 +194,7 @@ affiliate = '0x0123456789012345678901234567890123456789'
 enable-rfqt = true
 enable-slippage-protection = true
         ",
-        api.address
+        node.address, api.address
     ));
     let engine = tests::SolverEngine::new("zeroex", config).await;
 


### PR DESCRIPTION
Same as https://github.com/cowprotocol/services/pull/2565.

Some solvers seem to be over-estimating gas costs and some underestimating.
To stop bleeding money a simple gas estimate offset should be enough.
Eventually we need to find a way to make things correct without this, though.

While working on this I also noticed that we only simulate gas costs for limit orders. I adjusted the code to always simulate solutions and compute a fee for any thing but liquidity orders and orders with a signed fee.
This caused some tests to fail so I added some mock nodes that return the required gas value to make the tests work as before.