### PR TITLE
Remove gas price from 0x and 1Inch requests

### DIFF
--- a/src/infra/dex/mod.rs
+++ b/src/infra/dex/mod.rs
@@ -30,8 +30,8 @@ impl Dex {
     ) -> Result<dex::Swap, Error> {
         let swap = match self {
             Dex::Balancer(balancer) => balancer.swap(order, slippage, gas_price).await?,
-            Dex::OneInch(oneinch) => oneinch.swap(order, slippage, gas_price).await?,
-            Dex::ZeroEx(zeroex) => zeroex.swap(order, slippage, gas_price).await?,
+            Dex::OneInch(oneinch) => oneinch.swap(order, slippage).await?,
+            Dex::ZeroEx(zeroex) => zeroex.swap(order, slippage).await?,
             Dex::ParaSwap(paraswap) => paraswap.swap(order, slippage, tokens).await?,
         };
         Ok(swap)

--- a/src/infra/dex/oneinch/dto.rs
+++ b/src/infra/dex/oneinch/dto.rs
@@ -3,7 +3,7 @@
 
 use {
     crate::{
-        domain::{auction, dex, order},
+        domain::{dex, order},
         util::serialize,
     },
     bigdecimal::BigDecimal,
@@ -88,12 +88,7 @@ pub struct Query {
 }
 
 impl Query {
-    pub fn with_domain(
-        self,
-        order: &dex::Order,
-        slippage: &dex::Slippage,
-        gas_price: auction::GasPrice,
-    ) -> Option<Self> {
+    pub fn with_domain(self, order: &dex::Order, slippage: &dex::Slippage) -> Option<Self> {
         // Buy orders are not supported on 1Inch
         if order.side == order::Side::Buy {
             return None;
@@ -104,7 +99,6 @@ impl Query {
             to_token_address: order.buy.0,
             amount: order.amount.get(),
             slippage: Slippage::from_domain(slippage),
-            gas_price: Some(gas_price.0 .0),
             ..self
         })
     }

--- a/src/infra/dex/oneinch/mod.rs
+++ b/src/infra/dex/oneinch/mod.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        domain::{auction, dex, eth},
+        domain::{dex, eth},
         util,
     },
     ethereum_types::H160,
@@ -107,12 +107,11 @@ impl OneInch {
         &self,
         order: &dex::Order,
         slippage: &dex::Slippage,
-        gas_price: auction::GasPrice,
     ) -> Result<dex::Swap, Error> {
         let query = self
             .defaults
             .clone()
-            .with_domain(order, slippage, gas_price)
+            .with_domain(order, slippage)
             .ok_or(Error::OrderNotSupported)?;
         let swap = {
             // Set up a tracing span to make debugging of API requests easier.

--- a/src/infra/dex/zeroex/dto.rs
+++ b/src/infra/dex/zeroex/dto.rs
@@ -3,7 +3,7 @@
 
 use {
     crate::{
-        domain::{auction, dex, order},
+        domain::{dex, order},
         util::serialize,
     },
     bigdecimal::BigDecimal,
@@ -76,12 +76,7 @@ pub struct Query {
 pub struct Slippage(BigDecimal);
 
 impl Query {
-    pub fn with_domain(
-        self,
-        order: &dex::Order,
-        slippage: &dex::Slippage,
-        gas_price: auction::GasPrice,
-    ) -> Self {
+    pub fn with_domain(self, order: &dex::Order, slippage: &dex::Slippage) -> Self {
         let (sell_amount, buy_amount) = match order.side {
             order::Side::Buy => (None, Some(order.amount.get())),
             order::Side::Sell => (Some(order.amount.get()), None),
@@ -95,7 +90,6 @@ impl Query {
             // Note that the API calls this "slippagePercentage", but it is **not** a
             // percentage but a factor.
             slippage_percentage: Some(Slippage(slippage.as_factor().clone())),
-            gas_price: Some(gas_price.0 .0),
             ..self
         }
     }

--- a/src/infra/dex/zeroex/mod.rs
+++ b/src/infra/dex/zeroex/mod.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        domain::{auction, dex, eth, order},
+        domain::{dex, eth, order},
         util,
     },
     ethereum_types::H160,
@@ -78,12 +78,8 @@ impl ZeroEx {
         &self,
         order: &dex::Order,
         slippage: &dex::Slippage,
-        gas_price: auction::GasPrice,
     ) -> Result<dex::Swap, Error> {
-        let query = self
-            .defaults
-            .clone()
-            .with_domain(order, slippage, gas_price);
+        let query = self.defaults.clone().with_domain(order, slippage);
         let quote = {
             // Set up a tracing span to make debugging of API requests easier.
             // Historically, debugging API requests to external DEXs was a bit

--- a/src/tests/oneinch/market_order.rs
+++ b/src/tests/oneinch/market_order.rs
@@ -56,8 +56,7 @@ async fn sell() {
                 &slippage=1\
                 &protocols=UNISWAP_V1%2CUNISWAP_V2%2CSUSHI\
                 &referrerAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41\
-                &disableEstimate=true\
-                &gasPrice=15000000000"
+                &disableEstimate=true"
             ),
             res: json!(
               {

--- a/src/tests/oneinch/out_of_price.rs
+++ b/src/tests/oneinch/out_of_price.rs
@@ -59,8 +59,7 @@ async fn sell() {
                 &slippage=1\
                 &protocols=UNISWAP_V1%2CUNISWAP_V2%2CSUSHI\
                 &referrerAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41\
-                &disableEstimate=true\
-                &gasPrice=15000000000"
+                &disableEstimate=true"
             ),
             res: json!(
               {

--- a/src/tests/zeroex/market_order.rs
+++ b/src/tests/zeroex/market_order.rs
@@ -15,7 +15,6 @@ async fn sell() {
              &buyToken=0xe41d2489571d322189246dafa5ebde1f4699f498\
              &sellAmount=1000000000000000000\
              &slippagePercentage=0.01\
-             &gasPrice=15000000000\
              &takerAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41\
              &skipValidation=true\
              &intentOnFilling=false\
@@ -197,9 +196,9 @@ async fn buy() {
         path: mock::http::Path::exact(
             "swap/v1/quote?sellToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&\
              buyToken=0xe41d2489571d322189246dafa5ebde1f4699f498&buyAmount=1000000000000000000000&\
-             slippagePercentage=0.01&gasPrice=15000000000&\
-             takerAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41&skipValidation=true&\
-             intentOnFilling=false&affiliateAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41&\
+             slippagePercentage=0.01&takerAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41&\
+             skipValidation=true&intentOnFilling=false&\
+             affiliateAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41&\
              enableSlippageProtection=false",
         ),
         res: json!({

--- a/src/tests/zeroex/options.rs
+++ b/src/tests/zeroex/options.rs
@@ -14,7 +14,6 @@ async fn test() {
              &buyToken=0xe41d2489571d322189246dafa5ebde1f4699f498\
              &sellAmount=1000000000000000000\
              &slippagePercentage=0.1\
-             &gasPrice=15000000000\
              &takerAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41\
              &excludedSources=Uniswap_V2%2CBalancer_V2\
              &skipValidation=true\


### PR DESCRIPTION
To not exceed any request limits for expensive DEX APIs there is an nginx egress proxy that caches requests to not waste RPS on identical requests.
This for example enables multiple API pods to only issue 1 actual request to the DEX API while receiving the response for all of them.
However, this currently only works if the requested URL is actually completely identical. So far the gas price got specified with the request which means whenever the gas price changes slightly caching will not be possible.
In order to switch to the dex solver being used as quoters in a colocated manner this has to be addressed.
Luckily 0x and 1Inch use reasonable default values for the gas price so we don't actually have to provide them and there is no nginx caching for balancer so we don't have to worry about that either.

Removes `gasPrice` from the requests and updates unit tests accordingly.