### PR TITLE
Set `X-CURRENT-BLOCK-HASH` header on every request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,15 +72,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -127,7 +128,7 @@ checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 [[package]]
 name = "app-data"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "anyhow",
  "app-data-hash",
@@ -142,7 +143,7 @@ dependencies = [
 [[package]]
 name = "app-data-hash"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "hex-literal",
  "tiny-keccak",
@@ -169,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.74"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -707,7 +708,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 [[package]]
 name = "bytes-hex"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "hex",
  "serde",
@@ -727,11 +728,11 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.44.0"
+version = "0.49.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b195e4fbc4b6862bbd065b991a34750399c119797efff72492f28a5864de8700"
+checksum = "8e8e463fceca5674287f32d252fb1d94083758b8709c160efae66d263e5f4eba"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "instant",
  "once_cell",
  "thiserror",
@@ -767,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.11"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -777,23 +778,23 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.11"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -801,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -840,7 +841,7 @@ dependencies = [
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "ethcontract",
  "ethcontract-generate",
@@ -855,9 +856,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
  "percent-encoding",
  "time",
@@ -866,12 +867,12 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.16.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
 dependencies = [
  "cookie",
- "idna 0.2.3",
+ "idna 0.3.0",
  "log",
  "publicsuffix",
  "serde",
@@ -985,7 +986,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.60",
 ]
 
@@ -1003,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "database"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -1068,12 +1069,6 @@ dependencies = [
  "rustc_version",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1185,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract"
-version = "0.25.4"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28ee036fde35000df46c82ec67f2e9f5a6ebc53093e0af2a9b045cce9818acf"
+checksum = "bdea297be3b8157af960773a0df81c239a3c542022191b3fd909001ada670a0c"
 dependencies = [
  "arrayvec",
  "aws-config",
@@ -1211,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-common"
-version = "0.25.4"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422d0b0977f0855eaeab796ff5502302f5ac33ae96209c0ea81b0aa164dd370e"
+checksum = "f43c48f35e613bb9955e31851226066e74bedac9c0ed237294293821eb9a7cce"
 dependencies = [
  "ethabi",
  "hex",
@@ -1227,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "ethcontract-generate"
-version = "0.25.4"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c013062a68f3e5d6fa2db391134cfc5fb0ee64d8d15d6205d79ec7cf7e8ffa4"
+checksum = "b2da9ad91f85983c5352264d4a7b17510f89bed227b04ab641ae64f759d633b4"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1257,7 +1252,7 @@ dependencies = [
 [[package]]
 name = "ethrpc"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1280,6 +1275,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "url",
  "web3",
 ]
 
@@ -1330,15 +1326,6 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1396,9 +1383,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1411,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1421,15 +1408,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1449,15 +1436,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1466,15 +1453,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
@@ -1484,9 +1471,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1579,12 +1566,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -1634,6 +1615,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1828,17 +1815,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
@@ -1943,13 +1919,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
+name = "is_terminal_polyfill"
+version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1962,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2078,12 +2051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -2164,20 +2131,20 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "model"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "anyhow",
  "app-data",
@@ -2190,7 +2157,7 @@ dependencies = [
  "hex-literal",
  "lazy_static",
  "num",
- "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.253.0)",
+ "number",
  "primitive-types",
  "secp256k1",
  "serde",
@@ -2237,12 +2204,6 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2360,20 +2321,7 @@ dependencies = [
 [[package]]
 name = "number"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
-dependencies = [
- "anyhow",
- "bigdecimal",
- "num",
- "primitive-types",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "number"
-version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.255.1-temp-solvers#f16f528f62b3c5d3b15a66c4e5bedb65ca3d4803"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -2395,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "observe"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "atty",
  "futures",
@@ -2468,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "order-validation"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "cached",
  "contracts",
@@ -2581,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -2632,16 +2580,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
- "difflib",
- "float-cmp",
- "itertools 0.10.5",
- "normalize-line-endings",
+ "anstyle",
  "predicates-core",
- "regex",
 ]
 
 [[package]]
@@ -2798,7 +2742,7 @@ dependencies = [
 [[package]]
 name = "rate-limit"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "anyhow",
  "futures",
@@ -2867,9 +2811,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "async-compression",
  "base64 0.21.5",
@@ -2892,9 +2836,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3145,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -3272,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.253.0#2e6fbac515927e88dc40b720f1bb135cf8425075"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
  "anyhow",
  "app-data",
@@ -3296,13 +3242,13 @@ dependencies = [
  "hex-literal",
  "humantime",
  "indexmap 2.2.6",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "maplit",
  "mockall",
  "model",
  "num",
- "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.253.0)",
+ "number",
  "observe",
  "order-validation",
  "primitive-types",
@@ -3438,12 +3384,14 @@ dependencies = [
 [[package]]
 name = "solvers-dto"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.255.1-temp-solvers#f16f528f62b3c5d3b15a66c4e5bedb65ca3d4803"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
 dependencies = [
+ "app-data",
  "bigdecimal",
+ "bytes-hex",
  "chrono",
  "hex",
- "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.255.1-temp-solvers)",
+ "number",
  "serde",
  "serde_with",
  "web3",
@@ -3480,7 +3428,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]
@@ -3563,7 +3511,7 @@ dependencies = [
  "atomic-write-file",
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -3715,21 +3663,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "strum"
-version = "0.25.0"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3818,18 +3772,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3901,9 +3855,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3952,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,7 +2157,7 @@ dependencies = [
  "hex-literal",
  "lazy_static",
  "num",
- "number",
+ "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.258.0)",
  "primitive-types",
  "secp256k1",
  "serde",
@@ -2316,6 +2316,19 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.3",
  "libc",
+]
+
+[[package]]
+name = "number"
+version = "0.1.0"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.255.0#9cae92c9e6750a5994c0e6bd24ac626588f2258d"
+dependencies = [
+ "anyhow",
+ "bigdecimal",
+ "num",
+ "primitive-types",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -3248,7 +3261,7 @@ dependencies = [
  "mockall",
  "model",
  "num",
- "number",
+ "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.258.0)",
  "observe",
  "order-validation",
  "primitive-types",
@@ -3384,14 +3397,12 @@ dependencies = [
 [[package]]
 name = "solvers-dto"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.258.0#d8b01fcc7848a994d6e4a35af5f0b08da43b4f7e"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.255.0#9cae92c9e6750a5994c0e6bd24ac626588f2258d"
 dependencies = [
- "app-data",
  "bigdecimal",
- "bytes-hex",
  "chrono",
  "hex",
- "number",
+ "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.255.0)",
  "serde",
  "serde_with",
  "web3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bigdecimal = { version = "0.3", features = ["serde"] }
 chrono = { version = "0.4.38", features = ["serde"], default-features = false }
 clap = { version = "4", features = ["derive", "env"] }
 ethereum-types = "0.14"
-futures = "0.3"
+futures = "0.3.30"
 hex = "0.4"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"
@@ -40,12 +40,12 @@ tower-http = { version = "0.4", features = ["trace"] }
 tracing = "0.1"
 web3 = "0.19"
 
-contracts = { git = "https://github.com/cowprotocol/services.git", tag = "v2.253.0", package = "contracts" }
-ethrpc = { git = "https://github.com/cowprotocol/services.git", tag = "v2.253.0", package = "ethrpc" }
-observe = { git = "https://github.com/cowprotocol/services.git", tag = "v2.253.0", package = "observe" }
-shared = { git = "https://github.com/cowprotocol/services.git", tag = "v2.253.0", package = "shared" }
-dto =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.255.1-temp-solvers", package = "solvers-dto" }
-rate-limit =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.253.0", package = "rate-limit" }
+contracts = { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "contracts" }
+ethrpc = { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "ethrpc" }
+observe = { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "observe" }
+shared = { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "shared" }
+dto =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "solvers-dto" }
+rate-limit =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "rate-limit" }
 
 [dev-dependencies]
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ contracts = { git = "https://github.com/cowprotocol/services.git", tag = "v2.258
 ethrpc = { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "ethrpc" }
 observe = { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "observe" }
 shared = { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "shared" }
-dto =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "solvers-dto" }
+dto =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.255.0", package = "solvers-dto" }
 rate-limit =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.258.0", package = "rate-limit" }
 
 [dev-dependencies]

--- a/src/infra/config/dex/balancer/file.rs
+++ b/src/infra/config/dex/balancer/file.rs
@@ -41,6 +41,7 @@ pub async fn load(path: &Path) -> super::Config {
                 .map(eth::ContractAddress)
                 .unwrap_or(contracts.balancer_vault),
             settlement: base.contracts.settlement,
+            block_stream: base.block_stream.clone(),
         },
         base,
     }

--- a/src/infra/config/dex/mod.rs
+++ b/src/infra/config/dex/mod.rs
@@ -25,5 +25,5 @@ pub struct Config {
     pub smallest_partial_fill: eth::Ether,
     pub rate_limiting_strategy: rate_limit::Strategy,
     pub gas_offset: eth::Gas,
-    pub block_stream: CurrentBlockStream,
+    pub block_stream: Option<CurrentBlockStream>,
 }

--- a/src/infra/config/dex/mod.rs
+++ b/src/infra/config/dex/mod.rs
@@ -6,6 +6,7 @@ pub mod zeroex;
 
 use {
     crate::domain::{dex::slippage, eth},
+    ethrpc::current_block::CurrentBlockStream,
     std::num::NonZeroUsize,
 };
 
@@ -24,4 +25,5 @@ pub struct Config {
     pub smallest_partial_fill: eth::Ether,
     pub rate_limiting_strategy: rate_limit::Strategy,
     pub gas_offset: eth::Gas,
+    pub block_stream: CurrentBlockStream,
 }

--- a/src/infra/config/dex/oneinch/file.rs
+++ b/src/infra/config/dex/oneinch/file.rs
@@ -67,6 +67,7 @@ pub async fn load(path: &Path) -> super::Config {
             main_route_parts: config.main_route_parts,
             connector_tokens: config.connector_tokens,
             complexity_level: config.complexity_level,
+            block_stream: base.block_stream.clone(),
         },
         base,
     }

--- a/src/infra/config/dex/paraswap/file.rs
+++ b/src/infra/config/dex/paraswap/file.rs
@@ -43,6 +43,7 @@ pub async fn load(path: &Path) -> super::Config {
             exclude_dexs: config.exclude_dexs,
             address: config.address,
             partner: config.partner,
+            block_stream: base.block_stream.clone(),
         },
         base,
     }

--- a/src/infra/config/dex/zeroex/file.rs
+++ b/src/infra/config/dex/zeroex/file.rs
@@ -75,6 +75,7 @@ pub async fn load(path: &Path) -> super::Config {
             settlement,
             enable_rfqt: config.enable_rfqt,
             enable_slippage_protection: config.enable_slippage_protection,
+            block_stream: base.block_stream.clone(),
         },
         base,
     }

--- a/src/infra/dex/balancer/mod.rs
+++ b/src/infra/dex/balancer/mod.rs
@@ -23,7 +23,7 @@ pub struct Sor {
 
 pub struct Config {
     /// Stream that yields every new block.
-    pub block_stream: CurrentBlockStream,
+    pub block_stream: Option<CurrentBlockStream>,
 
     /// The URL for the Balancer SOR API.
     pub endpoint: reqwest::Url,

--- a/src/infra/dex/oneinch/mod.rs
+++ b/src/infra/dex/oneinch/mod.rs
@@ -42,7 +42,7 @@ pub struct Config {
     pub complexity_level: Option<u32>,
 
     /// Stream that yields every new block.
-    pub block_stream: CurrentBlockStream,
+    pub block_stream: Option<CurrentBlockStream>,
 }
 
 pub enum Liquidity {

--- a/src/infra/dex/paraswap/mod.rs
+++ b/src/infra/dex/paraswap/mod.rs
@@ -4,6 +4,7 @@ use {
         util,
     },
     ethereum_types::Address,
+    ethrpc::current_block::CurrentBlockStream,
 };
 
 mod dto;
@@ -12,7 +13,7 @@ pub const DEFAULT_URL: &str = "https://apiv5.paraswap.io";
 
 /// Bindings to the ParaSwap API.
 pub struct ParaSwap {
-    client: reqwest::Client,
+    client: super::Client,
     config: Config,
 }
 
@@ -29,12 +30,15 @@ pub struct Config {
 
     /// Our partner name.
     pub partner: String,
+
+    /// A stream that yields every new block.
+    pub block_stream: CurrentBlockStream,
 }
 
 impl ParaSwap {
     pub fn new(config: Config) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: super::Client::new(Default::default(), config.block_stream.clone()),
             config,
         }
     }
@@ -76,8 +80,7 @@ impl ParaSwap {
     ) -> Result<dto::Price, Error> {
         let price = util::http::roundtrip!(
             <dto::Price, dto::Error>;
-            self.client
-                .get(util::url::join(&self.config.endpoint, "prices"))
+            self.client.request(reqwest::Method::GET, util::url::join(&self.config.endpoint, "prices"))
                 .query(&dto::PriceQuery::new(&self.config, order, tokens)?)
         )
         .await?;
@@ -96,7 +99,7 @@ impl ParaSwap {
         let transaction = util::http::roundtrip!(
             <dto::Transaction, dto::Error>;
             self.client
-                .post(util::url::join(
+                .request(reqwest::Method::POST, util::url::join(
                     &self.config.endpoint,
                     "transactions/1?ignoreChecks=true",
                 ))

--- a/src/infra/dex/paraswap/mod.rs
+++ b/src/infra/dex/paraswap/mod.rs
@@ -32,7 +32,7 @@ pub struct Config {
     pub partner: String,
 
     /// A stream that yields every new block.
-    pub block_stream: CurrentBlockStream,
+    pub block_stream: Option<CurrentBlockStream>,
 }
 
 impl ParaSwap {

--- a/src/infra/dex/zeroex/mod.rs
+++ b/src/infra/dex/zeroex/mod.rs
@@ -19,9 +19,6 @@ pub struct ZeroEx {
 }
 
 pub struct Config {
-    /// The stream that yields every new block.
-    pub block_stream: CurrentBlockStream,
-
     /// The base URL for the 0x swap API.
     pub endpoint: reqwest::Url,
 
@@ -46,6 +43,9 @@ pub struct Config {
 
     /// Whether or not to enable slippage protection.
     pub enable_slippage_protection: bool,
+
+    /// The stream that yields every new block.
+    pub block_stream: Option<CurrentBlockStream>,
 }
 
 impl ZeroEx {


### PR DESCRIPTION
Introduces a new optional argument `current-block-poll-interval`. When that is set we create a `CurrentBlockStream` and use the current block hash to populate the `X-CURRENT-BLOCK-HASH` header on every http request.
I only made it optional to not have to introduce a bunch of mocking logic in tests for a minor feature.

Also updates dependencies to the backend crates with the exception of `solvers-dto`. Upgrading that requires a bunch of changes in unit tests which are already covered in #19.