### PR TITLE
Properly parse paraswap rate limits

### DIFF
--- a/src/infra/dex/paraswap/mod.rs
+++ b/src/infra/dex/paraswap/mod.rs
@@ -134,7 +134,7 @@ impl From<util::http::RoundtripError<dto::Error>> for Error {
                 "ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT"
                 | "No routes found with enough liquidity"
                 | "Too much slippage on quote, please try again" => Self::NotFound,
-                "Rate limited" => Self::RateLimited,
+                "Rate limited" | "Rate limit pricing" => Self::RateLimited,
                 _ => Self::Api(err.error),
             },
         }

--- a/src/infra/dex/paraswap/mod.rs
+++ b/src/infra/dex/paraswap/mod.rs
@@ -134,6 +134,7 @@ impl From<util::http::RoundtripError<dto::Error>> for Error {
                 "ESTIMATED_LOSS_GREATER_THAN_MAX_IMPACT"
                 | "No routes found with enough liquidity"
                 | "Too much slippage on quote, please try again" => Self::NotFound,
+                "Rate limited" => Self::RateLimited,
                 _ => Self::Api(err.error),
             },
         }


### PR DESCRIPTION
Currently, paraswap rate limits are classified as errors of type [`Other`](https://github.com/gnosis/solvers/blob/6aa1b919fc6da83ef8b78fade7c2f50958ab6af7/src/domain/solver/dex/mod.rs#L140), which makes it hard to create proper alerting since rate limits are unfortunately somewhat expected.

The response paraswap sends in this case is

> received HTTP response status=429 Too Many Requests body={"error":"Rate limited"}

Currently we have logic to correctly identify rate limits based on status code:

https://github.com/gnosis/solvers/blob/6aa1b919fc6da83ef8b78fade7c2f50958ab6af7/src/infra/dex/paraswap/mod.rs#L127-L130

However, since the response is json our roundtrip implementation parses this into an API error:

https://github.com/gnosis/solvers/blob/6aa1b919fc6da83ef8b78fade7c2f50958ab6af7/src/util/http.rs#L75-L83

This error doesn't expose the status code and is handled in a different branch of the error parsing. This PR adds a branch to correctly classify this API error based on its error text.

### Test Plan

Run Paraswap solver (with 10 concurrent requests), see correct classification of errors.