### PR TITLE
[Trivial] Adjust paraswap max price impact

### DIFF
--- a/src/infra/dex/paraswap/dto.rs
+++ b/src/infra/dex/paraswap/dto.rs
@@ -49,6 +49,9 @@ pub struct PriceQuery {
 
     /// The partner name
     pub partner: String,
+
+    /// The maximum price impact accepted (in percentage, 0-100)
+    pub max_impact: u8,
 }
 
 impl PriceQuery {
@@ -74,6 +77,7 @@ impl PriceQuery {
             exclude_dexs: config.exclude_dexs.clone(),
             network: "1".to_owned(),
             partner: config.partner.clone(),
+            max_impact: 100,
         })
     }
 }

--- a/src/tests/paraswap/market_order.rs
+++ b/src/tests/paraswap/market_order.rs
@@ -11,7 +11,7 @@ async fn sell() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100",
             ),
             res: json!({
               "priceRoute": {
@@ -260,7 +260,7 @@ async fn buy() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100",
             ),
             res: json!({
               "priceRoute": {

--- a/src/tests/paraswap/out_of_price.rs
+++ b/src/tests/paraswap/out_of_price.rs
@@ -14,7 +14,7 @@ async fn sell() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100",
             ),
             res: json!({
               "priceRoute": {
@@ -218,7 +218,7 @@ async fn buy() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow",
+                "prices?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100",
             ),
             res: json!({
               "priceRoute": {


### PR DESCRIPTION
The next frequent unactionable we are seeing is 

> WARN request{id="16737"}:/solve:auction{id=8885257}:solve{order=0x0f013df7d8b2a4199e20b7f92fd03cb3fe24bad11ecf9a4a09354035825ccd130be2340d942e79dfef172392429855de8a4f5b14664f7bdd}: solvers::domain::solver::dex: failed to get swap err=Api("Validation failed: Can't process priceRoute with max impact reached")

https://developers.paraswap.network/api/get-rate-for-a-token-pair documents that we can simply set maxImpact to 100 to circumvent this check.

This is ok, because we anyways check the user's limit price and are ok with settling them as long as the limit is satisfied.

## Test Plan

Run in local shadow mode. Before PR we saw these errors locally, now we no longer do.