### PR TITLE
Add support for arbitrum

### DIFF
--- a/src/domain/eth/chain.rs
+++ b/src/domain/eth/chain.rs
@@ -6,6 +6,7 @@ pub enum ChainId {
     Mainnet = 1,
     Goerli = 5,
     Gnosis = 100,
+    Arbitrum = 42161,
 }
 
 impl ChainId {
@@ -21,6 +22,7 @@ impl ChainId {
             1 => Ok(Self::Mainnet),
             5 => Ok(Self::Goerli),
             100 => Ok(Self::Gnosis),
+            42161 => Ok(Self::Arbitrum),
             _ => Err(UnsupportedChain),
         }
     }
@@ -31,6 +33,7 @@ impl ChainId {
             ChainId::Mainnet => "1",
             ChainId::Goerli => "5",
             ChainId::Gnosis => "100",
+            ChainId::Arbitrum => "42161",
         }
     }
 

--- a/src/domain/eth/chain.rs
+++ b/src/domain/eth/chain.rs
@@ -6,7 +6,7 @@ pub enum ChainId {
     Mainnet = 1,
     Goerli = 5,
     Gnosis = 100,
-    Arbitrum = 42161,
+    ArbitrumOne = 42161,
 }
 
 impl ChainId {
@@ -22,7 +22,7 @@ impl ChainId {
             1 => Ok(Self::Mainnet),
             5 => Ok(Self::Goerli),
             100 => Ok(Self::Gnosis),
-            42161 => Ok(Self::Arbitrum),
+            42161 => Ok(Self::ArbitrumOne),
             _ => Err(UnsupportedChain),
         }
     }
@@ -33,7 +33,7 @@ impl ChainId {
             ChainId::Mainnet => "1",
             ChainId::Goerli => "5",
             ChainId::Gnosis => "100",
-            ChainId::Arbitrum => "42161",
+            ChainId::ArbitrumOne => "42161",
         }
     }
 

--- a/src/infra/config/dex/paraswap/file.rs
+++ b/src/infra/config/dex/paraswap/file.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        domain::eth,
+        domain::eth::{self, ChainId},
         infra::{config::dex::file, dex::paraswap},
     },
     serde::Deserialize,
@@ -25,6 +25,9 @@ struct Config {
 
     /// Which partner to identify as to the paraswap API.
     pub partner: String,
+
+    /// Which chain the solver is serving.
+    pub chain_id: u64,
 }
 
 /// Load the ParaSwap solver configuration from a TOML file.
@@ -43,6 +46,7 @@ pub async fn load(path: &Path) -> super::Config {
             exclude_dexs: config.exclude_dexs,
             address: config.address,
             partner: config.partner,
+            chain_id: ChainId::new(config.chain_id.into()).unwrap(),
         },
         base,
     }

--- a/src/infra/dex/paraswap/dto.rs
+++ b/src/infra/dex/paraswap/dto.rs
@@ -72,7 +72,7 @@ impl PriceQuery {
             },
             amount: order.amount.get(),
             exclude_dexs: config.exclude_dexs.clone(),
-            network: "1".to_owned(),
+            network: config.chain_id.network_id().to_string(),
             partner: config.partner.clone(),
         })
     }

--- a/src/infra/dex/paraswap/mod.rs
+++ b/src/infra/dex/paraswap/mod.rs
@@ -29,6 +29,9 @@ pub struct Config {
 
     /// Our partner name.
     pub partner: String,
+
+    /// For which chain the solver is configured.
+    pub chain_id: eth::ChainId,
 }
 
 impl ParaSwap {
@@ -98,7 +101,7 @@ impl ParaSwap {
             self.client
                 .post(util::url::join(
                     &self.config.endpoint,
-                    "transactions/1?ignoreChecks=true",
+                    &format!("transactions/{}?ignoreChecks=true", self.config.chain_id.network_id())
                 ))
                 .json(&body)
         )


### PR DESCRIPTION
Extends the `ChainId` struct with `ArbitrumOne` and makes the paraswap solver send the correct API requests for the configured network.