### PR TITLE
Handle zeroex legal error

### DIFF
--- a/src/domain/solver/dex/mod.rs
+++ b/src/domain/solver/dex/mod.rs
@@ -137,6 +137,9 @@ impl Dex {
                 err @ infra::dex::Error::RateLimited => {
                     tracing::debug!(?err, "encountered rate limit")
                 }
+                err @ infra::dex::Error::UnavailableForLegalReasons => {
+                    tracing::debug!(?err, "unavailable for legal reasons")
+                }
                 infra::dex::Error::Other(err) => {
                     tracing::warn!(?err, "failed to get swap")
                 }

--- a/src/infra/dex/mod.rs
+++ b/src/infra/dex/mod.rs
@@ -52,6 +52,8 @@ pub enum Error {
     NotFound,
     #[error("rate limited")]
     RateLimited,
+    #[error("unavailable for legal reasons, banned tokens or similar")]
+    UnavailableForLegalReasons,
     #[error(transparent)]
     Other(Box<dyn std::error::Error + Send + Sync>),
 }
@@ -93,6 +95,7 @@ impl Error {
             Self::OrderNotSupported => "OrderNotSupported",
             Self::NotFound => "NotFound",
             Self::RateLimited => "RateLimited",
+            Self::UnavailableForLegalReasons => "UnavailableForLegalReasons",
             Self::Other(_) => "Other",
         }
     }
@@ -123,6 +126,7 @@ impl From<zeroex::Error> for Error {
         match err {
             zeroex::Error::NotFound => Self::NotFound,
             zeroex::Error::RateLimited => Self::RateLimited,
+            zeroex::Error::UnavailableForLegalReasons => Self::UnavailableForLegalReasons,
             _ => Self::Other(Box::new(err)),
         }
     }

--- a/src/infra/dex/oneinch/mod.rs
+++ b/src/infra/dex/oneinch/mod.rs
@@ -167,6 +167,8 @@ impl OneInch {
 pub enum Error {
     #[error("order type is not supported")]
     OrderNotSupported,
+    #[error("sell token or buy tokens are banned from trading")]
+    BannedTokens,
     #[error("no valid swap could be found")]
     NotFound,
     #[error("rate limited")]

--- a/src/infra/dex/oneinch/mod.rs
+++ b/src/infra/dex/oneinch/mod.rs
@@ -167,8 +167,6 @@ impl OneInch {
 pub enum Error {
     #[error("order type is not supported")]
     OrderNotSupported,
-    #[error("sell token or buy tokens are banned from trading")]
-    BannedTokens,
     #[error("no valid swap could be found")]
     NotFound,
     #[error("rate limited")]

--- a/src/infra/dex/zeroex/mod.rs
+++ b/src/infra/dex/zeroex/mod.rs
@@ -157,6 +157,8 @@ pub enum Error {
     MissingSpender,
     #[error("rate limited")]
     RateLimited,
+    #[error("sell token or buy token are banned from trading")]
+    UnavailableForLegalReasons,
     #[error("api error code {code}: {reason}")]
     Api { code: i64, reason: String },
     #[error(transparent)]
@@ -174,6 +176,7 @@ impl From<util::http::RoundtripError<dto::Error>> for Error {
                 match err.code {
                     100 => Self::NotFound,
                     429 => Self::RateLimited,
+                    451 => Self::UnavailableForLegalReasons,
                     _ => Self::Api {
                         code: err.code,
                         reason: err.reason,


### PR DESCRIPTION
We started receiving errors when trying to swap tokens that are apparently, for some reason, banned from trading on 0x API.

Quick fix is to define a separate error variant for this type of error, so it can be properly handled by our metrics system and not being considered "unexpected".

The alternative would be to define a black list of tokens for 0x api for which we know are banned and don't even send the requests for those. The obvious problem with this is that we don't know the reason why these tokens are banned and for how long. If they get unbanned we won't notice.