### PR TITLE
Properly classify Balancer rate limit error

### DIFF
--- a/src/infra/dex/mod.rs
+++ b/src/infra/dex/mod.rs
@@ -102,6 +102,7 @@ impl From<balancer::Error> for Error {
     fn from(err: balancer::Error) -> Self {
         match err {
             balancer::Error::NotFound => Self::NotFound,
+            balancer::Error::RateLimited => Self::RateLimited,
             _ => Self::Other(Box::new(err)),
         }
     }


### PR DESCRIPTION
Properly classifies balancer rate limit answers - so they are not classified as "Other" (unexpected) type of error.