### PR TITLE
ParaSwap new API

### DIFF
--- a/config/example.paraswap.toml
+++ b/config/example.paraswap.toml
@@ -6,6 +6,7 @@ relative-slippage = "0.001" # Percentage in the [0, 1] range
 # these 2 dexs should always be excluded because they are incompatible with `ignoreChecks`
 exclude-dexs = ["ParaSwapPool","ParaSwapLimitOrders"] # which dexs to ignore as liquidity sources
 address = "0xdd2e786980CD58ACc5F64807b354c981f4094936" # public address of the solver
-endpoint = "https://apiv5.paraswap.io" # paraswap API URL to use
+endpoint = "https://api-partners.paraswap.io" # paraswap API URL to use
+api-key = "$YOUR_API_KEY" # paraswap API key to use
 partner = "$YOUR_PARTNER_ID"
 chain-id = 1

--- a/src/infra/config/dex/paraswap/file.rs
+++ b/src/infra/config/dex/paraswap/file.rs
@@ -23,6 +23,10 @@ struct Config {
     /// The solver address.
     pub address: eth::H160,
 
+    /// This is needed when configuring ParaSwap to use
+    /// the gated API for partners.
+    pub api_key: String,
+
     /// Which partner to identify as to the paraswap API.
     pub partner: String,
 
@@ -45,6 +49,7 @@ pub async fn load(path: &Path) -> super::Config {
                 .unwrap_or_else(|| paraswap::DEFAULT_URL.parse().unwrap()),
             exclude_dexs: config.exclude_dexs,
             address: config.address,
+            api_key: config.api_key,
             partner: config.partner,
             chain_id: ChainId::new(config.chain_id.into()).unwrap(),
             block_stream: base.block_stream.clone(),

--- a/src/infra/dex/paraswap/mod.rs
+++ b/src/infra/dex/paraswap/mod.rs
@@ -28,6 +28,10 @@ pub struct Config {
     /// The solver address.
     pub address: Address,
 
+    /// ParaSwap provides a gated API for partners that requires authentication
+    /// by specifying this as header in the HTTP request.
+    pub api_key: String,
+
     /// Our partner name.
     pub partner: String,
 
@@ -84,6 +88,7 @@ impl ParaSwap {
         let price = util::http::roundtrip!(
             <dto::Price, dto::Error>;
             self.client.request(reqwest::Method::GET, util::url::join(&self.config.endpoint, "prices"))
+                .header("X-API-KEY", &self.config.api_key)
                 .query(&dto::PriceQuery::new(&self.config, order, tokens)?)
         )
         .await?;

--- a/src/tests/paraswap/mod.rs
+++ b/src/tests/paraswap/mod.rs
@@ -13,6 +13,7 @@ node-url = 'http://localhost:8545'
 endpoint = 'http://{solver_addr}'
 exclude-dexs = ['UniswapV2']
 address = '0xE0B3700e0aadcb18ed8d4BFF648Bc99896a18ad1'
+api-key = 'abc123'
 partner = 'cow'
 chain-id = 1
         ",


### PR DESCRIPTION
ParaSwap requested to switch to a new API, which requires `x-api-key` header to be provided.
`partner` still needs to be provided in the requests.