### PR TITLE
ParaSwap transactions api key

### DIFF
--- a/src/infra/dex/paraswap/mod.rs
+++ b/src/infra/dex/paraswap/mod.rs
@@ -111,6 +111,7 @@ impl ParaSwap {
                     &self.config.endpoint,
                     &format!("transactions/{}?ignoreChecks=true", self.config.chain_id.network_id())
                 ))
+                .header("X-API-KEY", &self.config.api_key)
                 .json(&body)
         )
         .await?;


### PR DESCRIPTION
Adds the missing api key header to the `/transactions` endpoint.