### PR TITLE
[TRIVIAL] Update contracts initialization comment

### DIFF
--- a/src/infra/config/dex/balancer/file.rs
+++ b/src/infra/config/dex/balancer/file.rs
@@ -30,7 +30,8 @@ struct Config {
 pub async fn load(path: &Path) -> super::Config {
     let (base, config) = file::load::<Config>(path).await;
 
-    // Balancer SOR solver only supports mainnet.
+    // Take advantage of the fact that deterministic deployment means that all
+    // CoW Protocol and Balancer Vault contracts have the same address.
     let contracts = contracts::Contracts::for_chain(eth::ChainId::Mainnet);
 
     super::Config {


### PR DESCRIPTION
Actualizes the comment on why the same contract can be used across all the networks.

Initially, I wanted to add a config param to make it clear, but then noticed another similar comment in the code.