### PR TITLE
Fix Paraswap missing decimals error

### DIFF
--- a/src/infra/dex/mod.rs
+++ b/src/infra/dex/mod.rs
@@ -136,7 +136,7 @@ impl From<zeroex::Error> for Error {
 impl From<paraswap::Error> for Error {
     fn from(err: paraswap::Error) -> Self {
         match err {
-            paraswap::Error::NotFound => Self::NotFound,
+            paraswap::Error::NotFound | paraswap::Error::MissingDecimals => Self::NotFound,
             paraswap::Error::RateLimited => Self::RateLimited,
             _ => Self::Other(Box::new(err)),
         }


### PR DESCRIPTION
Another noisy on-call error. Paraswap's API requires decimals for buy and sell token. If we don't have those for some reason we error early cf

https://github.com/gnosis/solvers/blob/94e3534fedc3b6bcfb3c7f95bcc4036bc76b055a/src/infra/dex/paraswap/dto.rs#L74

This error is currently treated as a generic `Other` error for which we alert.

This PR classifies this as a NoLiquidity error.