### PR TITLE
More reliable latest tag source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         id: tag_version
         run: |
           # Extracts the latest version tag, bumps the minor version
-          LATEST_VERSION=$(git tag --sort=-authordate --merged=main | head --lines 1)
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/gnosis/solvers/releases/latest | jq -r '.tag_name')
           if ! [[ "$LATEST_VERSION" =~ ^v[0-9]+\.[0-9]+\..* ]]; then
             echo "Invalid tag format, cannot bump version of: $LATEST_VERSION"
             exit 1


### PR DESCRIPTION
Uses a more reliable latest tag source in the release job since previously it could take some custom tags used for testing.
Previous release job failed because of this: https://github.com/gnosis/solvers/actions/runs/9831352675/job/27138614911