### PR TITLE
Paraswap: Add ignoreBadUsdPrice configuration for the swap query

### DIFF
--- a/src/infra/config/dex/paraswap/file.rs
+++ b/src/infra/config/dex/paraswap/file.rs
@@ -20,6 +20,10 @@ struct Config {
     #[serde(default)]
     pub exclude_dexs: Vec<String>,
 
+    /// Whether to throw an error if the USD price is not available.
+    #[serde(default)]
+    pub ignore_bad_usd_price: bool,
+
     /// The solver address.
     pub address: eth::H160,
 
@@ -48,6 +52,7 @@ pub async fn load(path: &Path) -> super::Config {
                 .endpoint
                 .unwrap_or_else(|| paraswap::DEFAULT_URL.parse().unwrap()),
             exclude_dexs: config.exclude_dexs,
+            ignore_bad_usd_price: config.ignore_bad_usd_price,
             address: config.address,
             api_key: config.api_key,
             partner: config.partner,

--- a/src/infra/dex/paraswap/dto.rs
+++ b/src/infra/dex/paraswap/dto.rs
@@ -60,6 +60,9 @@ pub struct SwapQuery {
 
     /// The API version to use.
     pub version: String,
+
+    /// Whether to throw an error if the USD price is not available.
+    pub ignore_bad_usd_price: bool,
 }
 
 impl SwapQuery {
@@ -84,6 +87,7 @@ impl SwapQuery {
             },
             amount: order.amount.get(),
             exclude_dexs: config.exclude_dexs.clone(),
+            ignore_bad_usd_price: config.ignore_bad_usd_price,
             network: config.chain_id.network_id().to_string(),
             partner: config.partner.clone(),
             max_impact: 100,

--- a/src/infra/dex/paraswap/mod.rs
+++ b/src/infra/dex/paraswap/mod.rs
@@ -25,6 +25,9 @@ pub struct Config {
     /// The DEXs to exclude when using ParaSwap.
     pub exclude_dexs: Vec<String>,
 
+    /// Whether to throw an error if the USD price is not available.
+    pub ignore_bad_usd_price: bool,
+
     /// The solver address.
     pub address: Address,
 

--- a/src/tests/paraswap/market_order.rs
+++ b/src/tests/paraswap/market_order.rs
@@ -11,7 +11,7 @@ async fn sell() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "swap?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100&userAddress=0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1&slippage=100&version=6.2",
+                "swap?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100&userAddress=0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1&slippage=100&version=6.2&ignoreBadUsdPrice=false",
             ),
             res: json!({
               "priceRoute": {
@@ -194,7 +194,7 @@ async fn buy() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "swap?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100&userAddress=0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1&slippage=100&version=6.2",
+                "swap?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100&userAddress=0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1&slippage=100&version=6.2&ignoreBadUsdPrice=false",
             ),
             res: json!({
               "priceRoute": {

--- a/src/tests/paraswap/out_of_price.rs
+++ b/src/tests/paraswap/out_of_price.rs
@@ -14,7 +14,7 @@ async fn sell() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "swap?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100&userAddress=0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1&slippage=100&version=6.2",
+                "swap?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000&side=SELL&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100&userAddress=0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1&slippage=100&version=6.2&ignoreBadUsdPrice=false",
             ),
             res: json!({
               "priceRoute": {
@@ -152,7 +152,7 @@ async fn buy() {
     let api = mock::http::setup(vec![
         mock::http::Expectation::Get {
             path: mock::http::Path::exact(
-                "swap?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100&userAddress=0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1&slippage=100&version=6.2",
+                "swap?srcToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&destToken=0xe41d2489571d322189246dafa5ebde1f4699f498&srcDecimals=18&destDecimals=18&amount=1000000000000000000000&side=BUY&excludeDEXS=UniswapV2&network=1&partner=cow&maxImpact=100&userAddress=0xe0b3700e0aadcb18ed8d4bff648bc99896a18ad1&slippage=100&version=6.2&ignoreBadUsdPrice=false",
             ),
             res: json!({
               "priceRoute": {


### PR DESCRIPTION
Some swaps were returning the error:

```
received HTTP response status=500 Internal Server Error body={"error":"Bad USD price"}
```

In order to avoid it, the query has to be extended with `&ignoreBadUsdPrice=true`