### PR TITLE
Fix gas estimation for orders created by settlement contract

### DIFF
--- a/src/domain/dex/mod.rs
+++ b/src/domain/dex/mod.rs
@@ -115,6 +115,7 @@ impl Swap {
         let gas = if order.class == order::Class::Limit {
             match simulator.gas(order.owner(), &self).await {
                 Ok(value) => value,
+                Err(infra::dex::simulator::Error::SettlementContractIsOwner) => self.gas,
                 Err(err) => {
                     tracing::warn!(?err, "gas simulation failed");
                     return None;

--- a/src/infra/dex/simulator.rs
+++ b/src/infra/dex/simulator.rs
@@ -35,6 +35,11 @@ impl Simulator {
     ///
     /// This will return a `None` if the gas simulation is unavailable.
     pub async fn gas(&self, owner: Address, swap: &dex::Swap) -> Result<eth::Gas, Error> {
+        if owner == self.settlement.0 {
+            // we can't have both the settlement and swapper contracts at the same address
+            return Err(Error::SettlementContractIsOwner);
+        }
+
         let swapper = contracts::support::Swapper::at(&self.web3, owner);
         let tx = swapper
             .methods()
@@ -125,4 +130,7 @@ pub enum Error {
 
     #[error("invalid return data")]
     InvalidReturnData,
+
+    #[error("can't simulate gas for an order for which the settlement contract is the owner")]
+    SettlementContractIsOwner,
 }


### PR DESCRIPTION
Gas simulator fails for all orders created by settlement contract (fee withdrawal orders for example). The reason is that swapper and settlement contract end up being deployed at the same address.

This is a quick oncall fix to use some default heuristic value in this specific case.