### PR TITLE
Classify 1Inch invalid token error correctly

### DIFF
--- a/src/infra/dex/oneinch/mod.rs
+++ b/src/infra/dex/oneinch/mod.rs
@@ -218,8 +218,8 @@ impl From<util::http::RoundtripError<dto::Error>> for Error {
                 // Unfortunately, AFAIK these codes aren't documented anywhere. These
                 // based on empirical observations of what the API has returned in the
                 // past.
-                match err.description.as_str() {
-                    "insufficient liquidity" => Self::NotFound,
+                match err.status_code {
+                    400 => Self::NotFound,
                     _ => Self::Api {
                         code: err.status_code,
                         description: err.description,


### PR DESCRIPTION
We have seen some unactionable 1Inch solver errors over the past few days. Looking at the logs, this is coming from API responses of the form:

> { code: 400, description: "not valid token" }

indicating that the 1Inch API cannot handle certain tokens. We already filter for insufficient liquidity (which also have a 400 code) so it sees appropriate to label all 400 errors as `NotFound`