### PR TITLE
Fix BalancerSOR empty response classification

### DIFF
--- a/src/infra/dex/balancer/dto.rs
+++ b/src/infra/dex/balancer/dto.rs
@@ -270,7 +270,7 @@ impl Quote {
     /// enough liquidity, no trading path, etc.). We don't consider this an
     /// error case.
     pub fn is_empty(&self) -> bool {
-        *self == Quote::default()
+        self.return_amount_raw.is_zero() && self.swap_amount_raw.is_zero() && self.swaps.is_empty()
     }
 }
 


### PR DESCRIPTION
We've gotten alerts about the BalancerSOR failing. Looking at the logs this comes from gas estimation errors (division by 0). It turns out that we are trying to turn "empty responses" (with 0 outcome tokens) into valid solutions, because our `is_empty` check no longer correct.

Here is how an empty response from the Balancer SOR API looks like (according to the logs):
> received HTTP response status=200 OK body={"data":{"sorGetSwapPaths":{"tokenAddresses":[],"swaps":[],"swapAmountRaw":"0","returnAmountRaw":"0","tokenIn":"0x8afe4055ebc86bd2afb3940c0095c9aca511d852","tokenOut":"0xe3dbc4f88eaa632ddf9708732e2832eeaa6688ab"}}}

As we can see, comparing this to `Quote::default()` will not yield true because `tokenIn` and `tokenOut` are not set to default.

This PR adjusts the check to look at swaps and swap amounts.