### PR TITLE
Remove Liquidity order type from Solvers 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,8 +142,23 @@ version = "0.1.0"
 source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.0#9619dd299c0105ca0a1206d8cac3bae3ed7bbf30"
 dependencies = [
  "anyhow",
- "app-data-hash",
- "bytes-hex",
+ "app-data-hash 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
+ "bytes-hex 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
+ "hex",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "app-data"
+version = "0.1.0"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.1#1c8c14fef21bef8753080ba6a74585d50ddd05ab"
+dependencies = [
+ "anyhow",
+ "app-data-hash 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.1)",
+ "bytes-hex 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.1)",
  "hex",
  "primitive-types",
  "serde",
@@ -155,6 +170,15 @@ dependencies = [
 name = "app-data-hash"
 version = "0.1.0"
 source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.0#9619dd299c0105ca0a1206d8cac3bae3ed7bbf30"
+dependencies = [
+ "hex-literal",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "app-data-hash"
+version = "0.1.0"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.1#1c8c14fef21bef8753080ba6a74585d50ddd05ab"
 dependencies = [
  "hex-literal",
  "tiny-keccak",
@@ -784,6 +808,17 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 name = "bytes-hex"
 version = "0.1.0"
 source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.0#9619dd299c0105ca0a1206d8cac3bae3ed7bbf30"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "bytes-hex"
+version = "0.1.0"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.1#1c8c14fef21bef8753080ba6a74585d50ddd05ab"
 dependencies = [
  "hex",
  "serde",
@@ -2438,17 +2473,17 @@ version = "0.1.0"
 source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.0#9619dd299c0105ca0a1206d8cac3bae3ed7bbf30"
 dependencies = [
  "anyhow",
- "app-data",
- "app-data-hash",
+ "app-data 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
+ "app-data-hash 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
  "bigdecimal",
- "bytes-hex",
+ "bytes-hex 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
  "chrono",
  "derivative",
  "hex",
  "hex-literal",
  "lazy_static",
  "num",
- "number",
+ "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
  "primitive-types",
  "secp256k1",
  "serde",
@@ -2605,6 +2640,19 @@ dependencies = [
 name = "number"
 version = "0.1.0"
 source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.0#9619dd299c0105ca0a1206d8cac3bae3ed7bbf30"
+dependencies = [
+ "anyhow",
+ "bigdecimal",
+ "num",
+ "primitive-types",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "number"
+version = "0.1.0"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.1#1c8c14fef21bef8753080ba6a74585d50ddd05ab"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -3651,11 +3699,11 @@ version = "0.1.0"
 source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.0#9619dd299c0105ca0a1206d8cac3bae3ed7bbf30"
 dependencies = [
  "anyhow",
- "app-data",
- "app-data-hash",
+ "app-data 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
+ "app-data-hash 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
  "async-trait",
  "bigdecimal",
- "bytes-hex",
+ "bytes-hex 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
  "cached",
  "chrono",
  "clap",
@@ -3678,7 +3726,7 @@ dependencies = [
  "mockall",
  "model",
  "num",
- "number",
+ "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
  "observe",
  "order-validation",
  "primitive-types",
@@ -3792,7 +3840,7 @@ dependencies = [
  "itertools 0.11.0",
  "maplit",
  "num",
- "number",
+ "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.0)",
  "observe",
  "prometheus",
  "prometheus-metric-storage",
@@ -3816,14 +3864,14 @@ dependencies = [
 [[package]]
 name = "solvers-dto"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.0#9619dd299c0105ca0a1206d8cac3bae3ed7bbf30"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.280.1#1c8c14fef21bef8753080ba6a74585d50ddd05ab"
 dependencies = [
- "app-data",
+ "app-data 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.1)",
  "bigdecimal",
- "bytes-hex",
+ "bytes-hex 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.1)",
  "chrono",
  "hex",
- "number",
+ "number 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.280.1)",
  "serde",
  "serde_with",
  "web3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ contracts = { git = "https://github.com/cowprotocol/services.git", tag = "v2.280
 ethrpc = { git = "https://github.com/cowprotocol/services.git", tag = "v2.280.0", package = "ethrpc" }
 observe = { git = "https://github.com/cowprotocol/services.git", tag = "v2.280.0", package = "observe" }
 shared = { git = "https://github.com/cowprotocol/services.git", tag = "v2.280.0", package = "shared" }
-dto =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.280.0", package = "solvers-dto" }
+dto =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.280.1", package = "solvers-dto" }
 rate-limit =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.280.0", package = "rate-limit" }
 number =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.280.0", package = "number" }
 

--- a/src/api/routes/solve/dto/auction.rs
+++ b/src/api/routes/solve/dto/auction.rs
@@ -56,7 +56,6 @@ pub fn to_domain(auction: &Auction) -> Result<auction::Auction, Error> {
                 class: match order.class {
                     Class::Market => order::Class::Market,
                     Class::Limit => order::Class::Limit,
-                    Class::Liquidity => order::Class::Liquidity,
                 },
                 partially_fillable: order.partially_fillable,
             })

--- a/src/domain/order.rs
+++ b/src/domain/order.rs
@@ -63,48 +63,6 @@ pub enum Side {
 pub enum Class {
     Market,
     Limit,
-    Liquidity,
-}
-
-/// A user order, guaranteed to not be a liquidity order.
-///
-/// Note that the concept of a user order is important enough to merit its own
-/// type. The reason for this is that these orders and liquidity orders differ
-/// in fundamental ways and we do not want to confuse them and accidentally use
-/// a liquidity order where it shouldn't be used. Some of the notable
-/// differences between the order types are:
-///
-/// - Liquidity orders can't be settled directly against on-chain liquidity.
-///   They are meant to only be used in CoWs to facilitate the trading of other
-///   non-liquidity orders.
-/// - Liquidity orders do not provide any solver rewards.
-///
-/// As their name suggests, they are meant as a mechanism for providing
-/// liquidity on CoW Protocol to other non-liquidity orders: they provide a
-/// mechanism for turning one token into another. In this regard, a liquidity
-/// order is conceptually similar to `liquidity::Liquidity`. One notable
-/// difference between the two is in how they are executed. General liquidity
-/// requires tokens up-front in order to exchange them for something else. On
-/// the other hand, liquidity orders are CoW Protocol orders, meaning that they
-/// first provide the tokens being swapped to and only get paid at the end of
-/// the settlement.
-#[derive(Clone, Copy, Debug)]
-pub struct UserOrder<'a>(&'a Order);
-
-impl<'a> UserOrder<'a> {
-    /// Wraps an order as a user order, returns `None` if the specified order is
-    /// not a user order.
-    pub fn new(order: &'a Order) -> Option<Self> {
-        match order.class {
-            Class::Market | Class::Limit => Some(Self(order)),
-            Class::Liquidity => None,
-        }
-    }
-
-    /// Returns a reference to the underlying CoW Protocol order.
-    pub fn get(&self) -> &'a Order {
-        self.0
-    }
 }
 
 /// An arbitrary ethereum interaction that is required for the settlement


### PR DESCRIPTION
Removes Liquidity order type from solvers domain as it's not used anymore: https://github.com/cowprotocol/services/pull/3059