### PR TITLE
Remove request body limit to accomodate growing auction instances

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::domain::solver::Solver,
+    axum::extract::DefaultBodyLimit,
     std::{future::Future, net::SocketAddr, sync::Arc},
     tokio::sync::oneshot,
 };
@@ -26,6 +27,7 @@ impl Api {
             .layer(
                 tower::ServiceBuilder::new().layer(tower_http::trace::TraceLayer::new_for_http()),
             )
+            .layer(DefaultBodyLimit::max(30_000_000))
             .with_state(Arc::new(self.solver));
 
         let make_svc = observe::make_service_with_task_local_storage!(app);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -27,7 +27,7 @@ impl Api {
             .layer(
                 tower::ServiceBuilder::new().layer(tower_http::trace::TraceLayer::new_for_http()),
             )
-            .layer(DefaultBodyLimit::max(30_000_000))
+            .layer(DefaultBodyLimit::disable())
             .with_state(Arc::new(self.solver));
 
         let make_svc = observe::make_service_with_task_local_storage!(app);


### PR DESCRIPTION
`axum` by default has a requests body limit of 2MB so when auction instances become bigger than that due to too many orders `axum` rejects the request before any handler gets the chance to see it.

I now removed the request limit altogether since these endpoints are not exposed to the public so we don't have to worry about malicious spam.