### PR TITLE
Handle 403 errors for 1inch requests

### DIFF
--- a/src/infra/dex/oneinch/mod.rs
+++ b/src/infra/dex/oneinch/mod.rs
@@ -219,7 +219,9 @@ impl From<util::http::RoundtripError<dto::Error>> for Error {
                 // based on empirical observations of what the API has returned in the
                 // past.
                 match err.status_code {
-                    400 => Self::NotFound,
+                    // 403 is returned when the 1inch quote API is forbidden due to legal reason for
+                    // a specific address or an artificial address was used in the request.
+                    400 | 403 => Self::NotFound,
                     _ => Self::Api {
                         code: err.status_code,
                         description: err.description,


### PR DESCRIPTION
From the original issue #95:

> The 1Inch API requires you to tell them which address wants to do the trade. Due to legal requirements they do not serve some addresses. In those cases the API call will return a 403 error.
Currently these get forwarded to the driver in a way that causes alerts like this although they are to be expected and don't indicate an error in the 1Inch API.

All the 403 errors are considered `NotFound` to reduce false alerts.

Fixes #95