### PR TITLE
Count total requests sent to dex API

### DIFF
--- a/src/domain/solver/dex/mod.rs
+++ b/src/domain/solver/dex/mod.rs
@@ -155,6 +155,7 @@ impl Dex {
             self.dex
                 .swap(dex_order, &slippage, tokens)
                 .await
+                .inspect(|_| infra::metrics::request_sent())
                 .map_err(dex_err_handler)
         };
         self.rate_limiter

--- a/src/infra/metrics.rs
+++ b/src/infra/metrics.rs
@@ -12,6 +12,9 @@ struct Metrics {
     #[metric(buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))]
     remaining_time: prometheus::Histogram,
 
+    /// Total number of requests that got sent to the DEX API.
+    solve_requests: prometheus::IntCounter,
+
     /// Errors that occurred during solving.
     #[metric(labels("reason"))]
     solve_errors: prometheus::IntCounterVec,
@@ -44,6 +47,10 @@ pub fn solved(deadline: &auction::Deadline, solutions: &[solution::Solution]) {
 
 pub fn solve_error(reason: &str) {
     get().solve_errors.with_label_values(&[reason]).inc();
+}
+
+pub fn request_sent() {
+    get().solve_requests.inc();
 }
 
 /// Get the metrics instance.


### PR DESCRIPTION
### Context

The oneinch solver on arbitrum currently causes a lot of noisy alerts which aren't really actionable.
When looking at the alert it appears as if ~40% of the request to the 1inch API return unexpected errors. However, after closer investigation it seems like this alert actually counts how many of the errors are unexpected errors.
Specifically for the arbitrum 1inch case <1% of all requests result in an unexpected error but 40% of all errors are unexpected.

Since 99% of the requests actually result in reasonable responses (albeit not good enough to satisfy the order's limit price) the 1inch solver should actually be considered healthy.

### Solution

The error handling logic is surprisingly messy: Errors are grouped in weird ways, handled in multiple places and used in conjunction with `Option`.
To resolve the noisy alert ASAP using a minimal patch without having to rethink all the error handling logic I decided to just introduce another metric which simply counts all requests sent to the API.
After this gets merged the alert should be updated to alert based on the ratio `unexpected_errors / total_requests` instead of `unexpected_errors / total_errors`