### PR TITLE
Swap froms from and to the settlement contract

### DIFF
--- a/src/infra/config/dex/okx/file.rs
+++ b/src/infra/config/dex/okx/file.rs
@@ -79,6 +79,7 @@ pub async fn load(path: &Path) -> super::Config {
             chain_id: config.chain_id,
             okx_credentials: config.okx_credentials.into(),
             block_stream: base.block_stream.clone(),
+            settlement_contract: base.contracts.settlement.0.into(),
         },
         base,
     }

--- a/src/infra/dex/okx/dto.rs
+++ b/src/infra/dex/okx/dto.rs
@@ -40,6 +40,9 @@ pub struct SwapRequest {
 
     /// User's wallet address. Where the sell tokens will be taken from.
     pub user_wallet_address: H160,
+
+    /// Where the buy tokens get sent to.
+    pub swap_receiver_address: H160,
 }
 
 /// A OKX slippage amount.
@@ -58,7 +61,6 @@ impl SwapRequest {
             to_token_address: order.buy.0,
             amount: order.amount.get(),
             slippage: Slippage(slippage.as_factor().clone()),
-            user_wallet_address: order.owner,
             ..self
         })
     }

--- a/src/infra/dex/okx/mod.rs
+++ b/src/infra/dex/okx/mod.rs
@@ -43,6 +43,8 @@ pub struct Config {
 
     pub chain_id: eth::ChainId,
 
+    pub settlement_contract: eth::Address,
+
     /// Credentials used to access OKX API.
     pub okx_credentials: OkxCredentialsConfig,
 
@@ -90,6 +92,10 @@ impl Okx {
 
         let defaults = dto::SwapRequest {
             chain_id: config.chain_id as u64,
+            // Funds first get moved in and out of the settlement contract so we have use
+            // that address here to generate the correct calldata.
+            swap_receiver_address: config.settlement_contract.into(),
+            user_wallet_address: config.settlement_contract.into(),
             ..Default::default()
         };
 

--- a/src/tests/okx/api_calls.rs
+++ b/src/tests/okx/api_calls.rs
@@ -21,6 +21,9 @@ async fn swap_sell() {
             api_secret_key: env::var("OKX_SECRET_KEY").unwrap(),
             api_passphrase: env::var("OKX_PASSPHRASE").unwrap(),
         },
+        settlement_contract: Address::from(
+            H160::from_str("0x9008d19f58aabd9ed0d60971565aa8510560ab41").unwrap(),
+        ),
         block_stream: None,
     };
 
@@ -62,6 +65,9 @@ async fn swap_buy() {
             api_secret_key: String::new(),
             api_passphrase: String::new(),
         },
+        settlement_contract: Address::from(
+            H160::from_str("0x9008d19f58aabd9ed0d60971565aa8510560ab41").unwrap(),
+        ),
         block_stream: None,
     };
 
@@ -101,6 +107,9 @@ async fn swap_api_error() {
             api_secret_key: env::var("OKX_SECRET_KEY").unwrap(),
             api_passphrase: env::var("OKX_PASSPHRASE").unwrap(),
         },
+        settlement_contract: Address::from(
+            H160::from_str("0x9008d19f58aabd9ed0d60971565aa8510560ab41").unwrap(),
+        ),
         block_stream: None,
     };
 
@@ -141,6 +150,9 @@ async fn swap_sell_insufficient_liquidity() {
             api_secret_key: env::var("OKX_SECRET_KEY").unwrap(),
             api_passphrase: env::var("OKX_PASSPHRASE").unwrap(),
         },
+        settlement_contract: Address::from(
+            H160::from_str("0x9008d19f58aabd9ed0d60971565aa8510560ab41").unwrap(),
+        ),
         block_stream: None,
     };
 

--- a/src/tests/okx/market_order.rs
+++ b/src/tests/okx/market_order.rs
@@ -16,7 +16,8 @@ async fn sell() {
                 &fromTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\
                 &toTokenAddress=0xe41d2489571d322189246dafa5ebde1f4699f498\
                 &slippage=0.01\
-                &userWalletAddress=0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                &userWalletAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41\
+                &swapReceiverAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41"
             ),
             res: json!(
               {

--- a/src/tests/okx/not_found.rs
+++ b/src/tests/okx/not_found.rs
@@ -13,7 +13,8 @@ async fn sell() {
             "swap?chainId=1&amount=1000000000000000000&\
              fromTokenAddress=0xc8cd2be653759aed7b0996315821aae71e1feadf&\
              toTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&slippage=0.01&\
-             userWalletAddress=0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
+             userWalletAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41&\
+             swapReceiverAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41"
         ),
         res: json!({"code":"82000","data":[],"msg":"Insufficient liquidity."}),
     }])
@@ -86,7 +87,8 @@ async fn sell_no_approve_transaction() {
                 &fromTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\
                 &toTokenAddress=0xe41d2489571d322189246dafa5ebde1f4699f498\
                 &slippage=0.01\
-                &userWalletAddress=0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                &userWalletAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41\
+                &swapReceiverAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41"
             ),
             res: json!(
               {

--- a/src/tests/okx/not_found.rs
+++ b/src/tests/okx/not_found.rs
@@ -14,7 +14,7 @@ async fn sell() {
              fromTokenAddress=0xc8cd2be653759aed7b0996315821aae71e1feadf&\
              toTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&slippage=0.01&\
              userWalletAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41&\
-             swapReceiverAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41"
+             swapReceiverAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41",
         ),
         res: json!({"code":"82000","data":[],"msg":"Insufficient liquidity."}),
     }])

--- a/src/tests/okx/out_of_price.rs
+++ b/src/tests/okx/out_of_price.rs
@@ -19,7 +19,8 @@ async fn sell() {
                 &fromTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\
                 &toTokenAddress=0xe41d2489571d322189246dafa5ebde1f4699f498\
                 &slippage=0.01\
-                &userWalletAddress=0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a"
+                &userWalletAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41\
+                &swapReceiverAddress=0x9008d19f58aabd9ed0d60971565aa8510560ab41"
             ),
             res: json!(
               {


### PR DESCRIPTION
The flow of money in cow protocol works like this:
```
user -> settlement_contract
                         -> AMM1
                         <-
                         -> Amm2
                         <-
    <-
```

Since OKX is effectively a stand if for the AMM interactions we need to build the calldata such that it would take tokens out of the settlement contract and also send them back there.