### PR TITLE
Fixes for 0x v2 support

### DIFF
--- a/src/infra/dex/zeroex/dto.rs
+++ b/src/infra/dex/zeroex/dto.rs
@@ -199,7 +199,7 @@ mod tests {
         }"#;
 
         let quote: super::Quote = serde_json::from_str(json).unwrap();
-        assert_eq!(quote.liquidity_available, true);
+        assert!(quote.liquidity_available);
     }
 
     #[test]
@@ -209,6 +209,6 @@ mod tests {
         }"#;
 
         let quote: super::Quote = serde_json::from_str(json).unwrap();
-        assert_eq!(quote.liquidity_available, false);
+        assert!(!quote.liquidity_available);
     }
 }

--- a/src/infra/dex/zeroex/dto.rs
+++ b/src/infra/dex/zeroex/dto.rs
@@ -1,5 +1,5 @@
 //! DTOs for the 0x swap API. Full documentation for the API can be found
-//! [here](https://docs.0x.org/0x-api-swap/api-references/get-swap-v1-quote).
+//! [here](https://0x.org/docs/api#tag/Swap/operation/swap::allowanceHolder::getQuote).
 
 use {
     crate::{
@@ -13,7 +13,7 @@ use {
 
 /// A 0x API quote query parameters.
 ///
-/// See [API](https://docs.0x.org/0x-api-swap/api-references/get-swap-v1-quote)
+/// See [API](https://0x.org/docs/api#tag/Swap/operation/swap::allowanceHolder::getQuote)
 /// documentation for more detailed information on each parameter.
 #[serde_as]
 #[derive(Clone, Default, Serialize)]

--- a/src/infra/dex/zeroex/dto.rs
+++ b/src/infra/dex/zeroex/dto.rs
@@ -82,8 +82,8 @@ impl Query {
 #[serde(rename_all = "camelCase")]
 pub struct Quote {
     /// The amount of sell token (in atoms) that would be sold in this swap.
-    #[serde_as(as = "serialize::U256")]
-    pub sell_amount: U256,
+    #[serde_as(as = "Option<serialize::U256>")]
+    pub sell_amount: Option<U256>,
 
     /// The amount of buy token (in atoms) that would be bought in this swap.
     #[serde_as(as = "serialize::U256")]

--- a/src/tests/zeroex/market_order.rs
+++ b/src/tests/zeroex/market_order.rs
@@ -16,6 +16,7 @@ async fn sell() {
              taker=0x9008d19f58aabd9ed0d60971565aa8510560ab41&slippageBps=100",
         ),
         res: json!({
+            "liquidityAvailable": true,
             "sellAmount": "1000000000000000000",
             "buyAmount": "5876422636675954000000",
             "transaction": {

--- a/src/tests/zeroex/options.rs
+++ b/src/tests/zeroex/options.rs
@@ -16,6 +16,7 @@ async fn test() {
              excludedSources=Uniswap_V2%2CBalancer_V2",
         ),
         res: json!({
+            "liquidityAvailable": true,
             "sellAmount": "1000000000000000000",
             "buyAmount": "5876422636675954000000",
             "transaction": {


### PR DESCRIPTION
Contains 2 fixes that were implicit and ~not documented~ (not visible to me) by 0x team in the migration document:

1. If sell/buy token is banned for legal reasons, the `422` error code is returned instead of `451`. The code handling this error code is added.
2. Apparently some quotes are returned without `sell_amount` in the response. As confirmed by 0x team, this is not a bug, since `liquidityAvailable` field should be `false` in that case. In any case, I don't see how these responses could be valid, so I classified them as `NotFound` errors.