### PR TITLE
Handle 0x swap validation error

### DIFF
--- a/src/infra/dex/zeroex/mod.rs
+++ b/src/infra/dex/zeroex/mod.rs
@@ -173,7 +173,9 @@ impl From<util::http::RoundtripError<dto::Error>> for Error {
                             Self::UnavailableForLegalReasons
                         }
                         StatusCode::UNPROCESSABLE_ENTITY => Self::UnavailableForLegalReasons,
-                        // This seem to be a expected Zeroex API response when not finding a trade
+                        // This mapping avoids false positives on some alarms that trigger due to
+                        // log messages on the Http variant TODO: remove
+                        // when the 0x team finds/fixes the root cause of this errors
                         StatusCode::BAD_REQUEST if body.contains("SWAP_VALIDATION_FAILED") => {
                             Self::NotFound
                         }

--- a/src/infra/dex/zeroex/mod.rs
+++ b/src/infra/dex/zeroex/mod.rs
@@ -173,12 +173,10 @@ impl From<util::http::RoundtripError<dto::Error>> for Error {
                             Self::UnavailableForLegalReasons
                         }
                         StatusCode::UNPROCESSABLE_ENTITY => Self::UnavailableForLegalReasons,
-                        // This seem to be a common Zeroex API response when not finding a trade
+                        // This seem to be a expected Zeroex API response when not finding a trade
                         StatusCode::BAD_REQUEST if body.contains("SWAP_VALIDATION_FAILED") => {
                             Self::NotFound
                         }
-                        // Also a common Zeroex API response when not finding a trade
-                        StatusCode::INTERNAL_SERVER_ERROR => Self::NotFound,
                         _ => Self::Http(err),
                     }
                 } else {


### PR DESCRIPTION
Currently, 0x API does return a lot of HTTP 400 errors with a `SWAP_VALIDATION_FAILED` message.

The root cause is being investigated by their team but meanwhile this triggers our alert system with false positives due the logs being:
```
solvers::domain::solver::dex: failed to get swap err=Http(Status(400, "{\"name\":\"SWAP_VALIDATION_FAILED\",\"message\":\"Swap validation failed\",\"data\":{\"zid\":\"0x.....\"}}"))
```

This PR maps this particular case to the `NotFound` variant to avoid it. So the resulting log lines will look like:
```
solvers::domain::solver::dex: skipping order err=NotFound
```