### PR TITLE
Bump `services` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 [[package]]
 name = "app-data"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "anyhow",
  "bytes-hex",
@@ -787,7 +787,7 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 [[package]]
 name = "bytes-hex"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "hex",
  "serde",
@@ -838,7 +838,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "chain"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "derive_more 1.0.0",
  "ethcontract",
@@ -981,18 +981,7 @@ dependencies = [
 [[package]]
 name = "contracts"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
-dependencies = [
- "anyhow",
- "ethcontract",
- "ethcontract-generate",
- "serde",
-]
-
-[[package]]
-name = "contracts"
-version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?branch=main#7de04a67d64c6ac3144a8c446c8f8b2615993123"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "anyhow",
  "ethcontract",
@@ -1193,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "database"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -1499,11 +1488,11 @@ dependencies = [
 [[package]]
 name = "ethrpc"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "anyhow",
  "async-trait",
- "contracts 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.306.0)",
+ "contracts",
  "ethcontract",
  "futures",
  "hex",
@@ -2630,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "model"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "anyhow",
  "app-data",
@@ -2826,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "number"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -2848,7 +2837,7 @@ dependencies = [
 [[package]]
 name = "observe"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "async-trait",
  "atty",
@@ -2923,9 +2912,9 @@ dependencies = [
 [[package]]
 name = "order-validation"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
- "contracts 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.306.0)",
+ "contracts",
  "ethcontract",
  "thiserror",
  "tokio",
@@ -3354,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "rate-limit"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "anyhow",
  "futures",
@@ -3911,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "anyhow",
  "app-data",
@@ -3922,7 +3911,7 @@ dependencies = [
  "chain",
  "chrono",
  "clap",
- "contracts 0.1.0 (git+https://github.com/cowprotocol/services.git?tag=v2.306.0)",
+ "contracts",
  "dashmap",
  "database",
  "derivative",
@@ -4039,7 +4028,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "clap",
- "contracts 0.1.0 (git+https://github.com/cowprotocol/services.git?branch=main)",
+ "contracts",
  "ethereum-types",
  "ethrpc",
  "futures",
@@ -4080,7 +4069,7 @@ dependencies = [
 [[package]]
 name = "solvers-dto"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "app-data",
  "bigdecimal",
@@ -4493,7 +4482,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "testlib"
 version = "0.1.0"
-source = "git+https://github.com/cowprotocol/services.git?tag=v2.306.0#7d857d0039fcc4fb80ce690a3dd5dc458afc0023"
+source = "git+https://github.com/cowprotocol/services.git?tag=v2.307.0#d2a7e87e95bb444aecb3450847f60b39e6c942bc"
 dependencies = [
  "anyhow",
  "ethcontract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tower-http = { version = "0.4", features = ["trace"] }
 tracing = "0.1"
 web3 = "0.19"
 
-contracts = { git = "https://github.com/cowprotocol/services.git", branch = "v2.307.0", package = "contracts" }
+contracts = { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "contracts" }
 ethrpc = { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "ethrpc" }
 observe = { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "observe" }
 shared = { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "shared" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,16 +47,16 @@ tower-http = { version = "0.4", features = ["trace"] }
 tracing = "0.1"
 web3 = "0.19"
 
-contracts = { git = "https://github.com/cowprotocol/services.git", branch = "main", package = "contracts" }
-ethrpc = { git = "https://github.com/cowprotocol/services.git", tag = "v2.306.0", package = "ethrpc" }
-observe = { git = "https://github.com/cowprotocol/services.git", tag = "v2.306.0", package = "observe" }
-shared = { git = "https://github.com/cowprotocol/services.git", tag = "v2.306.0", package = "shared" }
-dto =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.306.0", package = "solvers-dto" }
-rate-limit =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.306.0", package = "rate-limit" }
-number =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.306.0", package = "number" }
+contracts = { git = "https://github.com/cowprotocol/services.git", branch = "v2.307.0", package = "contracts" }
+ethrpc = { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "ethrpc" }
+observe = { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "observe" }
+shared = { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "shared" }
+dto =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "solvers-dto" }
+rate-limit =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "rate-limit" }
+number =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "number" }
 
 [dev-dependencies]
-testlib =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.306.0", package = "testlib" }
+testlib =  { git = "https://github.com/cowprotocol/services.git", tag = "v2.307.0", package = "testlib" }
 glob = "0.3"
 maplit = "1"
 tempfile = "3"


### PR DESCRIPTION
The job to automatically update the `services` dependencies after the weekly release [failed](https://github.com/gnosis/solvers/actions/runs/14743937960/job/41387621757). Most likely due to the fact that a custom target branch needed to be configured for the `contracts` crate.