### PR TITLE
Make balancer contracts non-mandatory

### DIFF
--- a/src/infra/contracts.rs
+++ b/src/infra/contracts.rs
@@ -5,29 +5,37 @@ pub struct Contracts {
     pub weth: eth::WethAddress,
     pub settlement: eth::ContractAddress,
     pub authenticator: eth::ContractAddress,
-    pub balancer_v2_vault: eth::ContractAddress,
-    pub balancer_v3_batch_router: eth::ContractAddress,
     pub permit2: eth::ContractAddress,
 }
 
 impl Contracts {
     pub fn for_chain(chain: eth::ChainId) -> Self {
-        let a = |contract: &contracts::ethcontract::Contract| {
-            eth::ContractAddress(
-                contract
-                    .networks
-                    .get(chain.network_id())
-                    .expect("contract address for all supported chains")
-                    .address,
-            )
-        };
         Self {
-            weth: eth::WethAddress(a(contracts::WETH9::raw_contract()).0),
-            settlement: a(contracts::GPv2Settlement::raw_contract()),
-            authenticator: a(contracts::GPv2AllowListAuthentication::raw_contract()),
-            balancer_v2_vault: a(contracts::BalancerV2Vault::raw_contract()),
-            balancer_v3_batch_router: a(contracts::BalancerV3BatchRouter::raw_contract()),
-            permit2: a(contracts::Permit2::raw_contract()),
+            weth: eth::WethAddress(
+                contract_address_for_chain(chain, contracts::WETH9::raw_contract()).0,
+            ),
+            settlement: contract_address_for_chain(
+                chain,
+                contracts::GPv2Settlement::raw_contract(),
+            ),
+            authenticator: contract_address_for_chain(
+                chain,
+                contracts::GPv2AllowListAuthentication::raw_contract(),
+            ),
+            permit2: contract_address_for_chain(chain, contracts::Permit2::raw_contract()),
         }
     }
+}
+
+pub fn contract_address_for_chain(
+    chain: eth::ChainId,
+    contract: &contracts::ethcontract::Contract,
+) -> eth::ContractAddress {
+    eth::ContractAddress(
+        contract
+            .networks
+            .get(chain.network_id())
+            .expect("contract address for all supported chains")
+            .address,
+    )
 }


### PR DESCRIPTION
While deploying on Polygon, it turned out that Balancer is not fully supported on this chain: https://docs.balancer.fi/developer-reference/contracts/deployment-addresses/polygon.html#active-contracts

The `Contracts` struct, which contains protocol and Balancer contracts in a single place, makes it impossible to spin up other solvers such as 0x, 1inch, in case Balancer is not supported on a particular chain, as on Polygon.

This PR fixes it by fetching the Balancer contracts info only when its solver is enabled.

Tested on Polygon.