### PR TITLE
Allow Balancer V2 usage separately from V3

### DIFF
--- a/src/infra/config/dex/balancer/file.rs
+++ b/src/infra/config/dex/balancer/file.rs
@@ -41,7 +41,7 @@ struct Config {
     query_batch_swap: Option<bool>,
 
     /// Controls which API versions are enabled.
-    /// Absence of this config param means all versions are supported.
+    /// Absence of this config param means all versions are enabled.
     enabled_api_versions: Option<Vec<ApiVersion>>,
 }
 

--- a/src/infra/config/dex/balancer/file.rs
+++ b/src/infra/config/dex/balancer/file.rs
@@ -41,6 +41,7 @@ struct Config {
     query_batch_swap: Option<bool>,
 
     /// Controls the maximum supported API version.
+    /// Absence of this config param means all versions are supported.
     supported_api_versions: Option<Vec<SupportedApiVersion>>,
 }
 

--- a/src/infra/dex/balancer/dto.rs
+++ b/src/infra/dex/balancer/dto.rs
@@ -202,19 +202,6 @@ impl Chain {
             eth::ChainId::Bnb | eth::ChainId::Goerli => Err(Error::UnsupportedChainId(chain_id)),
         }
     }
-
-    pub(crate) fn as_domain(&self) -> eth::ChainId {
-        match self {
-            Self::Mainnet => eth::ChainId::Mainnet,
-            Self::Gnosis => eth::ChainId::Gnosis,
-            Self::Arbitrum => eth::ChainId::ArbitrumOne,
-            Self::Base => eth::ChainId::Base,
-            Self::Avalanche => eth::ChainId::Avalanche,
-            Self::Polygon => eth::ChainId::Polygon,
-            Self::Optimism => eth::ChainId::Optimism,
-            _ => unreachable!(),
-        }
-    }
 }
 
 #[derive(Serialize)]

--- a/src/infra/dex/balancer/dto.rs
+++ b/src/infra/dex/balancer/dto.rs
@@ -202,6 +202,19 @@ impl Chain {
             eth::ChainId::Bnb | eth::ChainId::Goerli => Err(Error::UnsupportedChainId(chain_id)),
         }
     }
+
+    pub(crate) fn as_domain(&self) -> eth::ChainId {
+        match self {
+            Self::Mainnet => eth::ChainId::Mainnet,
+            Self::Gnosis => eth::ChainId::Gnosis,
+            Self::Arbitrum => eth::ChainId::ArbitrumOne,
+            Self::Base => eth::ChainId::Base,
+            Self::Avalanche => eth::ChainId::Avalanche,
+            Self::Polygon => eth::ChainId::Polygon,
+            Self::Optimism => eth::ChainId::Optimism,
+            _ => unreachable!(),
+        }
+    }
 }
 
 #[derive(Serialize)]

--- a/src/infra/dex/balancer/mod.rs
+++ b/src/infra/dex/balancer/mod.rs
@@ -6,7 +6,7 @@ use {
             eth::{self, TokenAddress},
             order::{self, Side},
         },
-        infra::dex::balancer::dto::Chain,
+        infra::{config::dex::balancer::file::ApiVersion, dex::balancer::dto::Chain},
         util,
     },
     contracts::ethcontract::I256,
@@ -92,8 +92,9 @@ impl Sor {
         slippage: &dex::Slippage,
         tokens: &auction::Tokens,
     ) -> Result<dex::Swap, Error> {
+        // Receiving this error indicates that V2 is now supported on the current chain.
         let Some(v2_vault) = &self.v2_vault else {
-            return Err(Error::UnsupportedChainId(self.chain_id.as_domain()));
+            return Err(Error::UnsupportedApiVersion(ApiVersion::V2));
         };
         let query = dto::Query::from_domain(
             order,
@@ -229,7 +230,7 @@ impl Sor {
     ) -> Result<Vec<dex::Call>, Error> {
         // Receiving this error indicates that V3 is now supported on the current chain.
         let Some(v3_batch_router) = &self.v3_batch_router else {
-            return Err(Error::UnsupportedChainId(self.chain_id.as_domain()));
+            return Err(Error::UnsupportedApiVersion(ApiVersion::V3));
         };
         let paths = quote
             .paths
@@ -302,6 +303,8 @@ pub enum Error {
     Http(util::http::Error),
     #[error("unsupported chain: {0:?}")]
     UnsupportedChainId(eth::ChainId),
+    #[error("unsupported API version: {0:?}")]
+    UnsupportedApiVersion(ApiVersion),
     #[error("decimals are missing for the swapped token: {0:?}")]
     MissingDecimals(TokenAddress),
     #[error("invalid pool id format")]

--- a/src/infra/dex/balancer/mod.rs
+++ b/src/infra/dex/balancer/mod.rs
@@ -94,7 +94,7 @@ impl Sor {
     ) -> Result<dex::Swap, Error> {
         // Receiving this error indicates that V2 is now supported on the current chain.
         let Some(v2_vault) = &self.v2_vault else {
-            return Err(Error::UnsupportedApiVersion(ApiVersion::V2));
+            return Err(Error::DisabledApiVersion(ApiVersion::V2));
         };
         let query = dto::Query::from_domain(
             order,
@@ -230,7 +230,7 @@ impl Sor {
     ) -> Result<Vec<dex::Call>, Error> {
         // Receiving this error indicates that V3 is now supported on the current chain.
         let Some(v3_batch_router) = &self.v3_batch_router else {
-            return Err(Error::UnsupportedApiVersion(ApiVersion::V3));
+            return Err(Error::DisabledApiVersion(ApiVersion::V3));
         };
         let paths = quote
             .paths
@@ -303,8 +303,8 @@ pub enum Error {
     Http(util::http::Error),
     #[error("unsupported chain: {0:?}")]
     UnsupportedChainId(eth::ChainId),
-    #[error("unsupported API version: {0:?}")]
-    UnsupportedApiVersion(ApiVersion),
+    #[error("disabled API version: {0:?}")]
+    DisabledApiVersion(ApiVersion),
     #[error("decimals are missing for the swapped token: {0:?}")]
     MissingDecimals(TokenAddress),
     #[error("invalid pool id format")]


### PR DESCRIPTION
Only Balancer V2 is currently supported on Polygon. V2 and V3 are coupled in the config, making it impossible to use the solver on this chain. This PR fixes this by adding a config for enabled API versions. BatchRouter won't be initialized if V3 is not specified in the config, and VaultV2 won't work without the corresponding config. Absence of the config means all versions are supported.

In case an API version is disabled and the solver starts sending errors showing the disabled API version is now supported, it can be quickly adjusted in the config.

Tested on Polygon: [cowprotocol/infrastructure@`af22e82` (#2987)](https://github.com/cowprotocol/infrastructure/pull/2987/commits/af22e82b7935675588f86884283ad2e24ef88c62)