### PR TITLE
Minimum slippage

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ target/
 # IDE specific
 /.vscode
 /.idea
+
+# AI
+.claude
+claude.md

--- a/src/domain/dex/minimum_surplus.rs
+++ b/src/domain/dex/minimum_surplus.rs
@@ -1,0 +1,151 @@
+//! Minimum surplus requirements for DEX swaps.
+
+use {
+    crate::{
+        domain::{auction, dex::shared, eth},
+        util::conv,
+    },
+    bigdecimal::{BigDecimal, Zero},
+    ethereum_types::U256,
+    std::cmp,
+};
+
+/// DEX swap minimum surplus limits.
+#[derive(Clone, Debug)]
+pub struct MinimumSurplusLimits {
+    /// The relative minimum surplus (percent) required for swaps.
+    relative: BigDecimal,
+    /// The absolute minimum surplus required for swaps.
+    absolute: Option<eth::Ether>,
+}
+
+impl MinimumSurplusLimits {
+    /// Creates a new minimum surplus limits configuration.
+    pub fn new(relative: BigDecimal, absolute: Option<eth::Ether>) -> Result<Self, anyhow::Error> {
+        anyhow::ensure!(
+            relative >= BigDecimal::zero(),
+            "minimum surplus relative tolerance must be non-negative"
+        );
+        Ok(Self { relative, absolute })
+    }
+
+    /// Returns the minimum surplus for the specified token amount.
+    pub fn relative(&self, asset: &eth::Asset, tokens: &auction::Tokens) -> MinimumSurplus {
+        let absolute_as_relative = shared::absolute_to_relative(self.absolute, asset, tokens);
+
+        MinimumSurplus::new(cmp::max(
+            self.relative.clone(),
+            absolute_as_relative.unwrap_or(BigDecimal::zero()),
+        ))
+    }
+}
+
+/// A relative minimum surplus requirement.
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
+pub struct MinimumSurplus(BigDecimal);
+
+impl MinimumSurplus {
+    /// Creates a new minimum surplus from a decimal value.
+    fn new(value: BigDecimal) -> Self {
+        Self(value)
+    }
+
+    /// Creates a minimum surplus from an absolute amount and reference amount.
+    fn from_amount(surplus_amount: U256, reference_amount: U256) -> Self {
+        let surplus = conv::u256_to_bigdecimal(&surplus_amount);
+        let reference = conv::u256_to_bigdecimal(&reference_amount);
+        Self(surplus / reference)
+    }
+
+    /// Adds minimum surplus to the specified amount.
+    pub fn add(&self, amount: U256) -> U256 {
+        let tolerance_amount = shared::compute_absolute_tolerance(amount, &self.0);
+        amount.saturating_add(tolerance_amount)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            domain::{auction, eth},
+            util::conv,
+        },
+    };
+
+    #[test]
+    fn minimum_surplus_requirement() {
+        let token = |t: &str| eth::TokenAddress(t.parse().unwrap());
+        let ether = |e: &str| conv::decimal_to_ether(&e.parse().unwrap()).unwrap();
+        let price = |e: &str| auction::Token {
+            decimals: Default::default(),
+            symbol: Default::default(),
+            reference_price: Some(auction::Price(ether(e))),
+            available_balance: Default::default(),
+            trusted: Default::default(),
+        };
+
+        let tokens = auction::Tokens(
+            [
+                // WETH
+                (
+                    token("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+                    price("1.0"),
+                ),
+                // USDC
+                (
+                    token("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+                    price("589783000.0"),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let minimum_surplus = MinimumSurplusLimits::new(
+            "0.01".parse().unwrap(), // 1%
+            Some(ether("0.02")),
+        )
+        .unwrap();
+
+        for (asset, relative, min_buy) in [
+            // Small amount: absolute minimum surplus dominates
+            // 0.5 WETH * 0.02/0.5 = 0.02 WETH absolute = 4% > 1% relative
+            (
+                eth::Asset {
+                    token: token("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+                    amount: 500_000_000_000_000_000_u128.into(), // 0.5 WETH
+                },
+                "0.04",
+                520_000_000_000_000_000_u128,
+            ),
+            // Medium amount: relative minimum surplus dominates
+            // 5 WETH * 1% = 0.05 WETH > 0.02 WETH absolute
+            (
+                eth::Asset {
+                    token: token("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+                    amount: 5_000_000_000_000_000_000_u128.into(), // 5 WETH
+                },
+                "0.01",
+                5_050_000_000_000_000_000_u128,
+            ),
+            // For USDC: relative dominates for this amount
+            (
+                eth::Asset {
+                    token: token("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+                    amount: 10_000_000_000_u128.into(), // 10K USDC
+                },
+                "0.01",
+                10_100_000_000_u128,
+            ),
+        ] {
+            let relative = MinimumSurplus::new(relative.parse().unwrap());
+            let min_buy = U256::from(min_buy);
+
+            let computed = minimum_surplus.relative(&asset, &tokens);
+
+            assert_eq!(computed, relative);
+            assert_eq!(computed.add(asset.amount), min_buy);
+        }
+    }
+}

--- a/src/domain/dex/mod.rs
+++ b/src/domain/dex/mod.rs
@@ -12,6 +12,8 @@ use {
     std::fmt::{self, Debug, Formatter},
 };
 
+pub mod minimum_surplus;
+mod shared;
 pub mod slippage;
 
 pub use self::slippage::Slippage;
@@ -157,6 +159,16 @@ impl Swap {
     pub fn satisfies(&self, order: &domain::order::Order) -> bool {
         self.output.amount.full_mul(order.sell.amount)
             >= self.input.amount.full_mul(order.buy.amount)
+    }
+
+    pub fn satisfies_with_minimum_surplus(
+        &self,
+        order: &domain::order::Order,
+        minimum_surplus: &minimum_surplus::MinimumSurplus,
+    ) -> bool {
+        let required_buy_amount = minimum_surplus.add(order.buy.amount);
+        self.output.amount.full_mul(order.sell.amount)
+            >= self.input.amount.full_mul(required_buy_amount)
     }
 }
 

--- a/src/domain/dex/shared.rs
+++ b/src/domain/dex/shared.rs
@@ -1,0 +1,48 @@
+//! Shared mathematical functions for slippage and minimum surplus calculations.
+
+use {
+    crate::{
+        domain::{auction, eth},
+        util::conv,
+    },
+    bigdecimal::BigDecimal,
+    ethereum_types::U256,
+    num::{BigUint, Integer},
+};
+
+/// Computes the absolute tolerance amount from a relative factor.
+pub fn compute_absolute_tolerance(amount: U256, factor: &BigDecimal) -> U256 {
+    let amount = conv::u256_to_biguint(&amount);
+    let (int, exp) = factor.as_bigint_and_exponent();
+
+    let numer = amount * int.to_biguint().expect("positive by construction");
+    let denom = BigUint::from(10_u8).pow(exp.unsigned_abs().try_into().unwrap_or(u32::MAX));
+
+    let abs = numer.div_ceil(&denom);
+    conv::biguint_to_u256(&abs).unwrap_or(U256::MAX)
+}
+
+/// Converts an absolute slippage value to a relative slippage value based on
+/// the amount and asset's price.
+pub fn absolute_to_relative(
+    absolute: Option<eth::Ether>,
+    asset: &eth::Asset,
+    tokens: &auction::Tokens,
+) -> Option<BigDecimal> {
+    let price = tokens.reference_price(&asset.token)?;
+    if price.0 .0.is_zero() {
+        return None;
+    }
+
+    // Convert absolute slippage and asset value to ETH using BigDecimal
+    let absolute = conv::ether_to_decimal(&absolute?);
+    let amount_in_token = conv::ether_to_decimal(&eth::Ether(asset.amount));
+    let price_in_eth = conv::ether_to_decimal(&price.0);
+
+    // Calculate asset value in ETH: amount * price
+    let amount_in_eth = amount_in_token * price_in_eth;
+
+    // Calculate absolute as relative: absolute_eth / asset_value_in_eth
+    let absolute_as_relative = absolute / amount_in_eth;
+    Some(absolute_as_relative)
+}

--- a/src/domain/dex/slippage.rs
+++ b/src/domain/dex/slippage.rs
@@ -2,109 +2,104 @@
 
 use {
     crate::{
-        domain::{auction, eth},
+        domain::{auction, dex::shared, eth},
         util::conv,
     },
-    bigdecimal::{BigDecimal, ToPrimitive},
+    bigdecimal::{BigDecimal, One, ToPrimitive, Zero},
     ethereum_types::U256,
-    num::{BigUint, Integer, One, Zero},
     std::cmp,
 };
 
-/// DEX swap slippage limits. The actual slippage used for a swap is bounded by
-/// a relative amount, and an absolute Ether value. These limits are used to
-/// determine the actual relative slippage to use for a particular asset (i.e.
-/// token and amount).
+/// DEX swap slippage limits.
 #[derive(Clone, Debug)]
-pub struct Limits {
+pub struct SlippageLimits {
+    /// The relative slippage (percent) allowed for swaps.
     relative: BigDecimal,
+    /// The maximum absolute slippage allowed for swaps.
     absolute: Option<eth::Ether>,
 }
 
-impl Limits {
-    /// Creates a new [`Limits`] instance. Returns `None` if the `relative`
-    /// slippage limit outside the valid range of [0, 1].
-    pub fn new(relative: BigDecimal, absolute: Option<eth::Ether>) -> Option<Self> {
-        (relative >= Zero::zero() && relative <= One::one()).then_some(Self { relative, absolute })
+impl SlippageLimits {
+    /// Creates a new slippage limits configuration.
+    pub fn new(relative: BigDecimal, absolute: Option<eth::Ether>) -> Result<Self, anyhow::Error> {
+        anyhow::ensure!(
+            relative >= BigDecimal::zero() && relative <= BigDecimal::one(),
+            "slippage relative tolerance must be in the range [0, 1]"
+        );
+        Ok(Self { relative, absolute })
     }
 
-    /// Computes the actual slippage tolerance to use for an asset using the
-    /// specified reference prices.
+    /// Returns the slippage for the specified token amount.
     pub fn relative(&self, asset: &eth::Asset, tokens: &auction::Tokens) -> Slippage {
-        if let (Some(absolute), Some(price)) =
-            (&self.absolute, tokens.reference_price(&asset.token))
-        {
-            let absolute = conv::ether_to_decimal(absolute);
-            let amount = conv::ether_to_decimal(&eth::Ether(asset.amount))
-                * conv::ether_to_decimal(&price.0);
+        let absolute_as_relative = shared::absolute_to_relative(self.absolute, asset, tokens);
 
-            let max_relative = absolute / amount;
-            let tolerance = cmp::min(max_relative, self.relative.clone());
-
-            Slippage(tolerance)
-        } else {
-            Slippage(self.relative.clone())
-        }
+        Slippage::new(cmp::min(
+            self.relative.clone(),
+            absolute_as_relative.unwrap_or(BigDecimal::one()),
+        ))
     }
 }
 
 /// A relative slippage tolerance.
-///
-/// Relative slippage has saturating semantics. I.e. if adding slippage to a
-/// token amount would overflow a `U256`, then `U256::max_value()` is returned
-/// instead.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Slippage(BigDecimal);
 
 impl Slippage {
+    /// Creates a new slippage from a decimal value.
+    fn new(value: BigDecimal) -> Self {
+        Self(value)
+    }
+
+    /// Creates a slippage from an absolute amount and reference amount.
+    fn from_amount(tolerance_amount: U256, reference_amount: U256) -> Self {
+        let tolerance = conv::u256_to_bigdecimal(&tolerance_amount);
+        let reference = conv::u256_to_bigdecimal(&reference_amount);
+        Self(tolerance / reference)
+    }
+
+    /// Returns 1% slippage.
     pub fn one_percent() -> Self {
-        Self("0.01".parse().unwrap())
+        Self::new("0.01".parse().unwrap())
     }
 
-    /// Adds slippage to the specified token amount. This can be used to account
-    /// for negative slippage in a sell amount.
+    /// Adds slippage to the specified amount.
     pub fn add(&self, amount: U256) -> U256 {
-        amount.saturating_add(self.abs(&amount))
+        let tolerance_amount = shared::compute_absolute_tolerance(amount, &self.0);
+        amount.saturating_add(tolerance_amount)
     }
 
-    /// Subtracts slippage to the specified token amount. This can be used to
-    /// account for negative slippage in a buy amount.
+    /// Subtracts slippage from the specified amount.
     pub fn sub(&self, amount: U256) -> U256 {
-        amount.saturating_sub(self.abs(&amount))
+        let tolerance_amount = shared::compute_absolute_tolerance(amount, &self.0);
+        amount.saturating_sub(tolerance_amount)
     }
 
-    /// Returns the absolute slippage amount.
-    fn abs(&self, amount: &U256) -> U256 {
-        let amount = conv::u256_to_biguint(amount);
-        let (int, exp) = self.0.as_bigint_and_exponent();
-
-        let numer = amount * int.to_biguint().expect("positive by construction");
-        let denom = BigUint::from(10_u8).pow(exp.unsigned_abs().try_into().unwrap_or(u32::MAX));
-
-        let abs = numer.div_ceil(&denom);
-        conv::biguint_to_u256(&abs).unwrap_or_else(U256::max_value)
-    }
-
-    /// Returns the relative slippage as a `BigDecimal` factor.
+    /// Returns the slippage as a decimal factor.
     pub fn as_factor(&self) -> &BigDecimal {
         &self.0
     }
 
-    /// Converts the relative slippage factor into basis points.
+    /// Converts the slippage to basis points.
     pub fn as_bps(&self) -> Option<u16> {
-        let basis_points = self.as_factor() * BigDecimal::from(10000);
-        basis_points.to_u16()
+        let bps = &self.0 * BigDecimal::from(10_000);
+        bps.to_u32().and_then(|v| v.try_into().ok())
     }
 
-    /// Rounds a relative slippage value to the specified decimal precision.
-    pub fn round(&self, arg: u32) -> Self {
-        Self(self.0.round(arg as _))
+    /// Rounds the slippage to the specified number of decimal places.
+    pub fn round(&self, decimals: i64) -> Self {
+        Self(self.0.round(decimals))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::domain::auction};
+    use {
+        super::*,
+        crate::{
+            domain::{auction, eth},
+            util::conv,
+        },
+    };
 
     #[test]
     fn slippage_tolerance() {
@@ -139,10 +134,11 @@ mod tests {
             .into_iter()
             .collect(),
         );
-        let slippage = Limits {
-            relative: "0.01".parse().unwrap(), // 1%
-            absolute: Some(ether("0.02")),
-        };
+        let slippage = SlippageLimits::new(
+            "0.01".parse().unwrap(), // 1%
+            Some(ether("0.02")),
+        )
+        .unwrap();
 
         for (asset, relative, min, max) in [
             // tolerance defined by relative slippage
@@ -152,8 +148,8 @@ mod tests {
                     amount: 1_000_000_000_000_000_000_u128.into(),
                 },
                 "0.01",
-                990_000_000_000_000_000,
-                1_010_000_000_000_000_000,
+                990_000_000_000_000_000_u128,
+                1_010_000_000_000_000_000_u128,
             ),
             // tolerance capped by absolute slippage
             (
@@ -162,8 +158,8 @@ mod tests {
                     amount: 100_000_000_000_000_000_000_u128.into(),
                 },
                 "0.0002",
-                99_980_000_000_000_000_000,
-                100_020_000_000_000_000_000,
+                99_980_000_000_000_000_000_u128,
+                100_020_000_000_000_000_000_u128,
             ),
             // tolerance defined by relative slippage
             (
@@ -172,8 +168,8 @@ mod tests {
                     amount: 1_000_000_000_u128.into(), // 1K USDC
                 },
                 "0.01",
-                990_000_000,
-                1_010_000_000,
+                990_000_000_u128,
+                1_010_000_000_u128,
             ),
             // tolerance capped by absolute slippage
             // 0.02 WETH <=> 33.91 USDC, and ~0.0033910778% of 1M
@@ -183,8 +179,8 @@ mod tests {
                     amount: 1_000_000_000_000_u128.into(), // 1M USDC
                 },
                 "0.000033911",
-                999_966_089_222,
-                1_000_033_910_778,
+                999_966_089_222_u128,
+                1_000_033_910_778_u128,
             ),
             // tolerance defined by relative slippage
             (
@@ -193,7 +189,7 @@ mod tests {
                     amount: 1_000_000_000_000_000_000_000_u128.into(), // 1K COW
                 },
                 "0.01",
-                990_000_000_000_000_000_000u128,
+                990_000_000_000_000_000_000_u128,
                 1_010_000_000_000_000_000_000_u128,
             ),
             // tolerance capped by absolute slippage
@@ -204,13 +200,13 @@ mod tests {
                     amount: 1_000_000_000_000_000_000_000_000_u128.into(), // 1M COW
                 },
                 "0.000350877",
-                999_649_122_807_017_543_859_649,
-                1_000_350_877_192_982_456_140_351,
+                999_649_122_807_017_543_859_649_u128,
+                1_000_350_877_192_982_456_140_351_u128,
             ),
         ] {
-            let relative = Slippage(relative.parse().unwrap());
-            let min = U256::from(min);
-            let max = U256::from(max);
+            let relative = Slippage::new(relative.parse().unwrap());
+            let min = ethereum_types::U256::from(min);
+            let max = ethereum_types::U256::from(max);
 
             let computed = slippage.relative(&asset, &tokens);
 
@@ -222,12 +218,12 @@ mod tests {
 
     #[test]
     fn round_does_not_panic() {
-        let slippage = Slippage(
+        let slippage = Slippage::new(
             "42.115792089237316195423570985008687907853269984665640564039457584007913129639935"
                 .parse()
                 .unwrap(),
         );
 
-        assert_eq!(slippage.round(4), Slippage("42.1158".parse().unwrap()));
+        assert_eq!(slippage.round(4), Slippage::new("42.1158".parse().unwrap()));
     }
 }

--- a/src/domain/solver/dex/mod.rs
+++ b/src/domain/solver/dex/mod.rs
@@ -5,7 +5,7 @@ use {
     crate::{
         domain::{
             auction,
-            dex::{self, slippage},
+            dex::{self, minimum_surplus::MinimumSurplusLimits, slippage::SlippageLimits},
             eth,
             order::{self, Order},
             solution,
@@ -28,7 +28,10 @@ pub struct Dex {
     simulator: infra::dex::Simulator,
 
     /// The slippage configuration to use for the solver.
-    slippage: slippage::Limits,
+    slippage: SlippageLimits,
+
+    /// The minimum surplus configuration to use for the solver.
+    minimum_surplus: MinimumSurplusLimits,
 
     /// The number of concurrent requests to make.
     concurrent_requests: NonZeroUsize,
@@ -67,6 +70,7 @@ impl Dex {
                 config.contracts.authenticator,
             ),
             slippage: config.slippage,
+            minimum_surplus: config.minimum_surplus,
             concurrent_requests: config.concurrent_requests,
             fills: Fills::new(config.smallest_partial_fill),
             rate_limiter,
@@ -169,14 +173,24 @@ impl Dex {
             .and_then(|result| result)
             .ok()
             .filter(|swap| {
-                let valid = swap.satisfies(order);
-                if !valid {
+                if !swap.satisfies(order) {
                     tracing::debug!("swap does not satisfy order");
+                    if order.partially_fillable {
+                        self.fills.reduce_next_try(order.uid);
+                    }
+                    return false;
                 }
-                if order.partially_fillable && !valid {
-                    self.fills.reduce_next_try(order.uid);
+
+                // Check minimum surplus requirement
+                let minimum_surplus = self.minimum_surplus.relative(&dex_order.amount(), tokens);
+                let valid_surplus = swap.satisfies_with_minimum_surplus(order, &minimum_surplus);
+                if !valid_surplus {
+                    tracing::debug!("swap does not meet minimum surplus requirement");
+                    if order.partially_fillable {
+                        self.fills.reduce_next_try(order.uid);
+                    }
                 }
-                valid
+                valid_surplus
             })
     }
 

--- a/src/infra/config/dex/file.rs
+++ b/src/infra/config/dex/file.rs
@@ -2,11 +2,14 @@
 
 use {
     crate::{
-        domain::{dex::slippage, eth},
+        domain::{
+            dex::{minimum_surplus::MinimumSurplusLimits, slippage::SlippageLimits},
+            eth,
+        },
         infra::{blockchain, config::unwrap_or_log, contracts},
         util::serialize,
     },
-    bigdecimal::BigDecimal,
+    bigdecimal::{BigDecimal, Zero},
     serde::{de::DeserializeOwned, Deserialize},
     serde_with::serde_as,
     std::{fmt::Debug, num::NonZeroUsize, path::Path, time::Duration},
@@ -33,6 +36,15 @@ struct Config {
     /// The absolute slippage allowed by the solver.
     #[serde_as(as = "Option<serialize::U256>")]
     absolute_slippage: Option<eth::U256>,
+
+    /// The relative minimum surplus required by the solver.
+    #[serde(default = "default_relative_minimum_surplus")]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    relative_minimum_surplus: BigDecimal,
+
+    /// The absolute minimum surplus required by the solver.
+    #[serde_as(as = "Option<serialize::U256>")]
+    absolute_minimum_surplus: Option<eth::U256>,
 
     /// The number of concurrent requests to make to the DEX aggregator API.
     #[serde(default = "default_concurrent_requests")]
@@ -80,6 +92,10 @@ struct Config {
 
 fn default_relative_slippage() -> BigDecimal {
     BigDecimal::new(1.into(), 2) // 1%
+}
+
+fn default_relative_minimum_surplus() -> BigDecimal {
+    BigDecimal::zero() // 0%
 }
 
 fn default_concurrent_requests() -> NonZeroUsize {
@@ -161,11 +177,16 @@ pub async fn load<T: DeserializeOwned>(path: &Path) -> (super::Config, T) {
             settlement,
             authenticator,
         },
-        slippage: slippage::Limits::new(
+        slippage: SlippageLimits::new(
             config.relative_slippage,
             config.absolute_slippage.map(eth::Ether),
         )
         .expect("invalid slippage limits"),
+        minimum_surplus: MinimumSurplusLimits::new(
+            config.relative_minimum_surplus,
+            config.absolute_minimum_surplus.map(eth::Ether),
+        )
+        .expect("invalid minimum surplus limits"),
         concurrent_requests: config.concurrent_requests,
         smallest_partial_fill: eth::Ether(config.smallest_partial_fill),
         rate_limiting_strategy: rate_limit::Strategy::try_new(

--- a/src/infra/config/dex/mod.rs
+++ b/src/infra/config/dex/mod.rs
@@ -6,7 +6,10 @@ pub mod paraswap;
 pub mod zeroex;
 
 use {
-    crate::domain::{dex::slippage, eth},
+    crate::domain::{
+        dex::{minimum_surplus::MinimumSurplusLimits, slippage::SlippageLimits},
+        eth,
+    },
     ethrpc::block_stream::CurrentBlockWatcher,
     std::num::NonZeroUsize,
 };
@@ -21,7 +24,8 @@ pub struct Contracts {
 pub struct Config {
     pub node_url: reqwest::Url,
     pub contracts: Contracts,
-    pub slippage: slippage::Limits,
+    pub slippage: SlippageLimits,
+    pub minimum_surplus: MinimumSurplusLimits,
     pub concurrent_requests: NonZeroUsize,
     pub smallest_partial_fill: eth::Ether,
     pub rate_limiting_strategy: rate_limit::Strategy,

--- a/src/tests/balancer/minimum_surplus.rs
+++ b/src/tests/balancer/minimum_surplus.rs
@@ -1,0 +1,540 @@
+//! This test verifies that the Balancer solver does not generate solutions when
+//! the swap returned from the API does not meet the minimum surplus
+//! requirement.
+//!
+//! This includes comprehensive testing of both buy and sell orders.
+
+use {
+    crate::tests::{
+        self,
+        balancer::{self, SWAP_QUERY},
+        mock,
+    },
+    serde_json::json,
+};
+
+#[tokio::test]
+async fn buy_order_insufficient_surplus() {
+    let api = mock::http::setup(vec![mock::http::Expectation::Post {
+        path: mock::http::Path::exact("sor"),
+        req: mock::http::RequestBody::Partial(json!({
+            "query": serde_json::to_value(SWAP_QUERY).unwrap(),
+            "variables": {
+                "callDataInput": {
+                  "receiver": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+                  "sender": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+                  "slippagePercentage": "0.01"
+                },
+                "chain": "MAINNET",
+                "queryBatchSwap": false,
+                "swapAmount": "230",
+                "swapType": "EXACT_OUT",
+                "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "tokenOut": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+            }
+        }), vec!["variables.callDataInput.deadline"]),
+        res: json!({
+            "data": {
+                "sorGetSwapPaths": {
+                    "tokenAddresses": [
+                        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                        "0xe41d2489571d322189246dafa5ebde1f4699f498"
+                    ],
+                    "swaps": [
+                        {
+                            "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+                            "assetInIndex": 0,
+                            "assetOutIndex": 1,
+                            "amount": "1000000000000000000",
+                            "userData": "0x",
+                        }
+                    ],
+                    // This exactly meets the order's limit price but doesn't provide 1% surplus
+                    "swapAmountRaw": "1000000000000000000",
+                    "returnAmountRaw": "230000000000000000000",
+                    "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "tokenOut": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "protocolVersion": 2,
+                    "paths": [
+                        {
+                            "inputAmountRaw": "1000000000000000000",
+                            "outputAmountRaw": "230000000000000000000",
+                            "protocolVersion": 2,
+                            "isBuffer": [false],
+                            "pools": [
+                                "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014"
+                            ],
+                            "tokens": [
+                                {
+                                    "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                                },
+                                {
+                                    "address": "0xe41d2489571d322189246dafa5ebde1f4699f498"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new(
+        "balancer",
+        balancer::config_with(&api.address, "relative-minimum-surplus = '0.01'"),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0xe41d2489571d322189246dafa5ebde1f4699f498": {
+                    "decimals": 18,
+                    "symbol": "ZRX",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "1583034704488033979459",
+                    "trusted": true,
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "1000000000000000000",
+                    "trusted": true,
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "sellAmount": "1000000000000000000", // Willing to pay up to 1 WETH
+                    "buyAmount": "230000000000000000000", // Want exactly 230 ZRX
+                    "fullSellAmount": "1000000000000000000",
+                    "fullBuyAmount": "230000000000000000000",
+                    "kind": "buy",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "sellTokenSource": "erc20",
+                    "buyTokenDestination": "erc20",
+                    "preInteractions": [],
+                    "postInteractions": [],
+                    "owner": "0x5b1e2c2762667331bc91648052f646d1b0d35984",
+                    "validTo": 0,
+                    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "signingScheme": "presign",
+                    "signature": "0x",
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": []
+        }),
+    );
+}
+
+#[tokio::test]
+async fn buy_order_with_sufficient_surplus() {
+    let api = mock::http::setup(vec![mock::http::Expectation::Post {
+        path: mock::http::Path::exact("sor"),
+        req: mock::http::RequestBody::Partial(json!({
+            "query": serde_json::to_value(SWAP_QUERY).unwrap(),
+            "variables": {
+                "callDataInput": {
+                  "receiver": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+                  "sender": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+                  "slippagePercentage": "0.01"
+                },
+                "chain": "MAINNET",
+                "queryBatchSwap": false,
+                "swapAmount": "230",
+                "swapType": "EXACT_OUT",
+                "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "tokenOut": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+            }
+        }), vec!["variables.callDataInput.deadline"]),
+        res: json!({
+            "data": {
+                "sorGetSwapPaths": {
+                    "tokenAddresses": [
+                        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                        "0xe41d2489571d322189246dafa5ebde1f4699f498"
+                    ],
+                    "swaps": [
+                        {
+                            "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+                            "assetInIndex": 0,
+                            "assetOutIndex": 1,
+                            "amount": "990000000000000000",
+                            "userData": "0x",
+                        }
+                    ],
+                    // This provides sufficient surplus (1%). User only needs to sell 0.99ETH (instead of 1ETH) for 230 ZRX order.
+                    "returnAmountRaw": "990000000000000000",
+                    "swapAmountRaw": "230000000000000000000",
+                    "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "tokenOut": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "protocolVersion": 2,
+                    "paths": [
+                        {
+                            "inputAmountRaw": "990000000000000000",
+                            "outputAmountRaw": "230000000000000000000",
+                            "protocolVersion": 2,
+                            "isBuffer": [false],
+                            "pools": [
+                                "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014"
+                            ],
+                            "tokens": [
+                                {
+                                    "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                                },
+                                {
+                                    "address": "0xe41d2489571d322189246dafa5ebde1f4699f498"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new(
+        "balancer",
+        balancer::config_with(&api.address, "relative-minimum-surplus = '0.005'"),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0xe41d2489571d322189246dafa5ebde1f4699f498": {
+                    "decimals": 18,
+                    "symbol": "ZRX",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "1583034704488033979459",
+                    "trusted": true,
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "1000000000000000000",
+                    "trusted": true,
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "sellAmount": "1000000000000000000", // Willing to pay up to 1 WETH
+                    "buyAmount": "230000000000000000000", // Want exactly 230 ZRX
+                    "fullSellAmount": "1000000000000000000",
+                    "fullBuyAmount": "230000000000000000000",
+                    "kind": "buy",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "sellTokenSource": "erc20",
+                    "buyTokenDestination": "erc20",
+                    "preInteractions": [],
+                    "postInteractions": [],
+                    "owner": "0x5b1e2c2762667331bc91648052f646d1b0d35984",
+                    "validTo": 0,
+                    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "signingScheme": "presign",
+                    "signature": "0x",
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
+        }))
+        .await
+        .unwrap();
+
+    // This should produce a solution since the swap provides sufficient surplus
+    assert_ne!(solution["solutions"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn sell_order_insufficient_surplus() {
+    let api = mock::http::setup(vec![mock::http::Expectation::Post {
+        path: mock::http::Path::exact("sor"),
+        req: mock::http::RequestBody::Partial(json!({
+            "query": serde_json::to_value(SWAP_QUERY).unwrap(),
+            "variables": {
+                "callDataInput": {
+                  "receiver": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+                  "sender": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+                  "slippagePercentage": "0.01"
+                },
+                "chain": "MAINNET",
+                "queryBatchSwap": false,
+                "swapAmount": "1",
+                "swapType": "EXACT_IN",
+                "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "tokenOut": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+            }
+        }), vec!["variables.callDataInput.deadline"]),
+        res: json!({
+            "data": {
+                "sorGetSwapPaths": {
+                    "tokenAddresses": [
+                        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                        "0xe41d2489571d322189246dafa5ebde1f4699f498"
+                    ],
+                    "swaps": [
+                        {
+                            "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+                            "assetInIndex": 0,
+                            "assetOutIndex": 1,
+                            "amount": "1000000000000000000",
+                            "userData": "0x",
+                        }
+                    ],
+                    "swapAmountRaw": "1000000000000000000",
+                    // This exactly meets the order's limit price but doesn't provide 1% surplus
+                    // Order expects at least 230 ZRX, swap returns exactly 230 (no surplus)
+                    "returnAmountRaw": "230000000000000000000",
+                    "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "tokenOut": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "protocolVersion": 2,
+                    "paths": [
+                        {
+                            "inputAmountRaw": "1000000000000000000",
+                            "outputAmountRaw": "230000000000000000000",
+                            "protocolVersion": 2,
+                            "isBuffer": [false],
+                            "pools": [
+                                "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014"
+                            ],
+                            "tokens": [
+                                {
+                                    "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                                },
+                                {
+                                    "address": "0xe41d2489571d322189246dafa5ebde1f4699f498"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new(
+        "balancer",
+        balancer::config_with(&api.address, "relative-minimum-surplus = '0.01'"),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0xe41d2489571d322189246dafa5ebde1f4699f498": {
+                    "decimals": 18,
+                    "symbol": "ZRX",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "1583034704488033979459",
+                    "trusted": true,
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "1000000000000000000",
+                    "trusted": true,
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "230000000000000000000", // Expecting at least 230 ZRX
+                    "fullSellAmount": "1000000000000000000",
+                    "fullBuyAmount": "230000000000000000000",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "sellTokenSource": "erc20",
+                    "buyTokenDestination": "erc20",
+                    "preInteractions": [],
+                    "postInteractions": [],
+                    "owner": "0x5b1e2c2762667331bc91648052f646d1b0d35984",
+                    "validTo": 0,
+                    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "signingScheme": "presign",
+                    "signature": "0x",
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
+        }))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        solution,
+        json!({
+            "solutions": []
+        }),
+    );
+}
+
+#[tokio::test]
+async fn sell_order_with_sufficient_surplus() {
+    let api = mock::http::setup(vec![mock::http::Expectation::Post {
+        path: mock::http::Path::exact("sor"),
+        req: mock::http::RequestBody::Partial(json!({
+            "query": serde_json::to_value(SWAP_QUERY).unwrap(),
+            "variables": {
+                "callDataInput": {
+                  "receiver": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+                  "sender": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+                  "slippagePercentage": "0.01"
+                },
+                "chain": "MAINNET",
+                "queryBatchSwap": false,
+                "swapAmount": "1",
+                "swapType": "EXACT_IN",
+                "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "tokenOut": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+            }
+        }), vec!["variables.callDataInput.deadline"]),
+        res: json!({
+            "data": {
+                "sorGetSwapPaths": {
+                    "tokenAddresses": [
+                        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                        "0xe41d2489571d322189246dafa5ebde1f4699f498"
+                    ],
+                    "swaps": [
+                        {
+                            "poolId": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+                            "assetInIndex": 0,
+                            "assetOutIndex": 1,
+                            "amount": "1000000000000000000",
+                            "userData": "0x",
+                        }
+                    ],
+                    "swapAmountRaw": "1000000000000000000",
+                    // This provides sufficient surplus: gives 235 ZRX for 230 ZRX order
+                    // With 1% surplus requirement, needs 232.3 ZRX, gets 235 ZRX (sufficient)
+                    "returnAmountRaw": "235000000000000000000",
+                    "tokenIn": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                    "tokenOut": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "protocolVersion": 2,
+                    "paths": [
+                        {
+                            "inputAmountRaw": "1000000000000000000",
+                            "outputAmountRaw": "235000000000000000000",
+                            "protocolVersion": 2,
+                            "isBuffer": [false],
+                            "pools": [
+                                "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014"
+                            ],
+                            "tokens": [
+                                {
+                                    "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+                                },
+                                {
+                                    "address": "0xe41d2489571d322189246dafa5ebde1f4699f498"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }),
+    }])
+    .await;
+
+    let engine = tests::SolverEngine::new(
+        "balancer",
+        balancer::config_with(&api.address, "relative-minimum-surplus = '0.01'"),
+    )
+    .await;
+
+    let solution = engine
+        .solve(json!({
+            "id": "1",
+            "tokens": {
+                "0xe41d2489571d322189246dafa5ebde1f4699f498": {
+                    "decimals": 18,
+                    "symbol": "ZRX",
+                    "referencePrice": "4327903683155778",
+                    "availableBalance": "1583034704488033979459",
+                    "trusted": true,
+                },
+                "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+                    "decimals": 18,
+                    "symbol": "WETH",
+                    "referencePrice": "1000000000000000000",
+                    "availableBalance": "1000000000000000000",
+                    "trusted": true,
+                },
+            },
+            "orders": [
+                {
+                    "uid": "0x2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a\
+                              2a2a2a2a",
+                    "sellToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "buyToken": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                    "sellAmount": "1000000000000000000",
+                    "buyAmount": "230000000000000000000", // Expecting at least 230 ZRX
+                    "fullSellAmount": "1000000000000000000",
+                    "fullBuyAmount": "230000000000000000000",
+                    "kind": "sell",
+                    "partiallyFillable": false,
+                    "class": "market",
+                    "sellTokenSource": "erc20",
+                    "buyTokenDestination": "erc20",
+                    "preInteractions": [],
+                    "postInteractions": [],
+                    "owner": "0x5b1e2c2762667331bc91648052f646d1b0d35984",
+                    "validTo": 0,
+                    "appData": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "signingScheme": "presign",
+                    "signature": "0x",
+                }
+            ],
+            "liquidity": [],
+            "effectiveGasPrice": "15000000000",
+            "deadline": "2106-01-01T00:00:00.000Z",
+            "surplusCapturingJitOrderOwners": []
+        }))
+        .await
+        .unwrap();
+
+    // This should produce a solution since the swap provides sufficient surplus
+    assert_ne!(solution["solutions"].as_array().unwrap().len(), 0);
+}

--- a/src/tests/balancer/mod.rs
+++ b/src/tests/balancer/mod.rs
@@ -1,6 +1,7 @@
 use {crate::tests, std::net::SocketAddr};
 
 mod market_order;
+mod minimum_surplus;
 mod not_found;
 mod out_of_price;
 
@@ -9,6 +10,20 @@ pub fn config(solver_addr: &SocketAddr) -> tests::Config {
     tests::Config::String(format!(
         r"
 node-url = 'http://localhost:8545'
+[dex]
+endpoint = 'http://{solver_addr}/sor'
+chain-id = '1'
+        ",
+    ))
+}
+
+/// Creates a temporary file containing the config of the given solver with
+/// custom top-level settings.
+pub fn config_with(solver_addr: &SocketAddr, extra_config: &str) -> tests::Config {
+    tests::Config::String(format!(
+        r"
+node-url = 'http://localhost:8545'
+{extra_config}
 [dex]
 endpoint = 'http://{solver_addr}/sor'
 chain-id = '1'


### PR DESCRIPTION
__This PR is a duplicate of #140 from @fleupold because that one ended up getting merged into the `devcontainer` branch instead of `main`.__

This PR was mainly implemented by Claude AI, so please review with caution (I did a full review pass myself). The size of the PR is reasonable if you discount the ~600 lines of added integration tests.

The goal of this PR is to address a noisy alert we are encountering mainly for the 0x solver which is aggressively trying to match user orders at the "arbitrage frontier", but then failing to settle those solutions (as the liquidity is sniped by non CoW arb bots).

To mitigate this, we introduce the concept of a minimum surplus below which we are not willing to bid on a given order. Similar to slippage limits, we allow to configure the minimum surplus to be either relative or absolute in terms of the order size.

## Changes
- [x] boilerplate logic to configure the new configuration parameters 
- [x] introduce the concept of min surplus as a strict copy of the existing slippage types and logic (first commit)
- [x] refactor to combine min surplus and max slippage into a single type (second commit)

## Test Plan

added unit tests