### PR TITLE
fix: prevent division by zero panic in slippage calculations

### DIFF
--- a/src/domain/dex/shared.rs
+++ b/src/domain/dex/shared.rs
@@ -7,7 +7,7 @@ use {
     },
     bigdecimal::BigDecimal,
     ethereum_types::U256,
-    num::{BigUint, Integer},
+    num::{BigUint, Integer, Zero},
 };
 
 /// Computes the absolute tolerance amount from a relative factor.
@@ -41,6 +41,11 @@ pub fn absolute_to_relative(
 
     // Calculate asset value in ETH: amount * price
     let amount_in_eth = amount_in_token * price_in_eth;
+
+    // Check if amount_in_eth is zero to prevent division by zero
+    if amount_in_eth.is_zero() {
+        return None;
+    }
 
     // Calculate absolute as relative: absolute_eth / asset_value_in_eth
     let absolute_as_relative = absolute / amount_in_eth;

--- a/src/domain/dex/shared.rs
+++ b/src/domain/dex/shared.rs
@@ -7,7 +7,7 @@ use {
     },
     bigdecimal::BigDecimal,
     ethereum_types::U256,
-    num::{BigUint, Integer, Zero},
+    num::{BigUint, Integer},
 };
 
 /// Computes the absolute tolerance amount from a relative factor.

--- a/src/domain/dex/slippage.rs
+++ b/src/domain/dex/slippage.rs
@@ -216,4 +216,38 @@ mod tests {
 
         assert_eq!(slippage.round(4), Slippage::new("42.1158".parse().unwrap()));
     }
+
+    #[test]
+    fn handles_zero_amount_without_panic() {
+        let token = |t: &str| eth::TokenAddress(t.parse().unwrap());
+        let ether = |e: &str| conv::decimal_to_ether(&e.parse().unwrap()).unwrap();
+        let price = |e: &str| auction::Token {
+            decimals: Default::default(),
+            reference_price: Some(auction::Price(ether(e))),
+            available_balance: Default::default(),
+            trusted: Default::default(),
+        };
+
+        let tokens = auction::Tokens(
+            [(token("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"), price("1.0"))]
+                .into_iter()
+                .collect(),
+        );
+
+        let slippage = SlippageLimits::new(
+            "0.01".parse().unwrap(), // 1%
+            Some(ether("0.02")),
+        )
+        .unwrap();
+
+        // Test with zero amount - should not panic and use relative slippage fallback
+        let asset_with_zero_amount = eth::Asset {
+            token: token("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            amount: 0.into(), // Zero amount
+        };
+
+        // This should not panic and should return the relative slippage (1%)
+        let computed = slippage.relative(&asset_with_zero_amount, &tokens);
+        assert_eq!(computed.as_factor(), &"0.01".parse::<BigDecimal>().unwrap());
+    }
 }


### PR DESCRIPTION
## Problem
The application was experiencing recurring panics with "Division by zero" errors in the slippage calculation logic. The stack trace showed the panic occurring in:
- `solvers::domain::dex::shared::absolute_to_relative` at line 46
- Called from `solvers::domain::dex::slippage::SlippageLimits::relative`

This happened when the `amount_in_eth` value was zero, which could occur in two scenarios:
1. Asset amount is zero (`asset.amount = 0`)
2. Price conversion results in zero value

## Solution
Added a zero-check guard before performing the division operation in the `absolute_to_relative` function:

1. **Added safety check**: Verify `amount_in_eth` is not zero before division
2. **Graceful fallback**: Return `None` when division by zero would occur
3. **Import Zero trait**: Added necessary import for `is_zero()` method
4. **Added test coverage**: Created test case to verify zero amount handling

## Changes
- `src/domain/dex/shared.rs`: Added zero check and Zero trait import
- `src/domain/dex/slippage.rs`: Added test case `handles_zero_amount_without_panic()`

## Impact
- ✅ **Eliminates crashes**: No more division by zero panics
- ✅ **Maintains functionality**: Existing behavior preserved for valid inputs  
- ✅ **Graceful degradation**: Falls back to relative slippage when absolute calculation isn't possible
- ✅ **Backward compatible**: No breaking changes to the API
