### PR TITLE
Support OKX API signature generation when using egress proxy

### DIFF
--- a/config/example.okx.toml
+++ b/config/example.okx.toml
@@ -13,6 +13,17 @@ chain-id = "1"
 # If not specified, buy orders will be ignored.
 # buy-orders-endpoint = "https://www.okx.com/api/v5/dex/aggregator/"
 
+# Optional: When using a proxy, specify the original OKX API URLs for signature generation
+# These URLs are used only for generating the request signature, while the actual requests
+# are sent to the endpoints configured above (sell-orders-endpoint and buy-orders-endpoint).
+# If not specified, the signature is generated using the endpoint URLs.
+#
+# Example proxy configuration:
+# sell-orders-endpoint = "https://your-proxy.example.com/okx/v6/"
+# sell-orders-signature-base-url = "https://web3.okx.com/api/v6/dex/aggregator/"
+# buy-orders-endpoint = "https://your-proxy.example.com/okx/v5/"
+# buy-orders-signature-base-url = "https://www.okx.com/api/v5/dex/aggregator/"
+
 # OKX Project ID. Instruction on how to create a project:
 # https://www.okx.com/en-au/web3/build/docs/waas/introduction-to-developer-portal-interface#create-project
 api-project-id = "$OKX_PROJECT_ID"

--- a/src/infra/config/dex/okx/file.rs
+++ b/src/infra/config/dex/okx/file.rs
@@ -26,6 +26,22 @@ struct Config {
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     buy_orders_endpoint: Option<reqwest::Url>,
 
+    /// Optional base URL to use for signature generation for sell orders.
+    /// This is useful when requests go through a proxy but signatures must be
+    /// generated using the original OKX API URL path.
+    /// If not specified, uses sell_orders_endpoint for signature generation.
+    #[serde(default)]
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    sell_orders_signature_base_url: Option<reqwest::Url>,
+
+    /// Optional base URL to use for signature generation for buy orders.
+    /// This is useful when requests go through a proxy but signatures must be
+    /// generated using the original OKX API URL path.
+    /// If not specified, uses buy_orders_endpoint for signature generation.
+    #[serde(default)]
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    buy_orders_signature_base_url: Option<reqwest::Url>,
+
     /// Chain ID used to automatically determine contract addresses.
     #[serde_as(as = "serialize::ChainId")]
     chain_id: eth::ChainId,
@@ -83,6 +99,8 @@ pub async fn load(path: &Path) -> super::Config {
         okx: okx::Config {
             sell_orders_endpoint: config.sell_orders_endpoint,
             buy_orders_endpoint: config.buy_orders_endpoint,
+            sell_orders_signature_base_url: config.sell_orders_signature_base_url,
+            buy_orders_signature_base_url: config.buy_orders_signature_base_url,
             chain_id: config.chain_id,
             okx_credentials: config.okx_credentials.into(),
             block_stream: base.block_stream.clone(),

--- a/src/infra/dex/mod.rs
+++ b/src/infra/dex/mod.rs
@@ -19,7 +19,7 @@ pub enum Dex {
     OneInch(oneinch::OneInch),
     ZeroEx(zeroex::ZeroEx),
     ParaSwap(paraswap::ParaSwap),
-    Okx(okx::Okx),
+    Okx(Box<okx::Okx>),
 }
 
 impl Dex {

--- a/src/infra/dex/okx/mod.rs
+++ b/src/infra/dex/okx/mod.rs
@@ -41,6 +41,8 @@ pub struct Okx {
     client: super::Client,
     sell_orders_endpoint: reqwest::Url,
     buy_orders_endpoint: Option<reqwest::Url>,
+    sell_orders_signature_base_url: reqwest::Url,
+    buy_orders_signature_base_url: Option<reqwest::Url>,
     api_secret_key: String,
     defaults: dto::SwapRequest,
     /// Cache which stores a map of (Token Address, Order Side) to contract
@@ -59,6 +61,18 @@ pub struct Config {
     /// If specified, the URL must point to the V5 API. Otherwise, buy orders
     /// will be ignored.
     pub buy_orders_endpoint: Option<reqwest::Url>,
+
+    /// Optional base URL to use for signature generation for sell orders.
+    /// This is useful when requests go through a proxy but signatures must be
+    /// generated using the original OKX API URL path.
+    /// If not specified, uses sell_orders_endpoint for signature generation.
+    pub sell_orders_signature_base_url: Option<reqwest::Url>,
+
+    /// Optional base URL to use for signature generation for buy orders.
+    /// This is useful when requests go through a proxy but signatures must be
+    /// generated using the original OKX API URL path.
+    /// If not specified, uses buy_orders_endpoint for signature generation.
+    pub buy_orders_signature_base_url: Option<reqwest::Url>,
 
     pub chain_id: eth::ChainId,
 
@@ -120,8 +134,14 @@ impl Okx {
 
         Ok(Self {
             client,
-            sell_orders_endpoint: config.sell_orders_endpoint,
-            buy_orders_endpoint: config.buy_orders_endpoint,
+            sell_orders_endpoint: config.sell_orders_endpoint.clone(),
+            buy_orders_endpoint: config.buy_orders_endpoint.clone(),
+            sell_orders_signature_base_url: config
+                .sell_orders_signature_base_url
+                .unwrap_or(config.sell_orders_endpoint),
+            buy_orders_signature_base_url: config
+                .buy_orders_signature_base_url
+                .or(config.buy_orders_endpoint),
             api_secret_key: config.okx_credentials.api_secret_key,
             defaults,
             dex_approved_addresses: Cache::new(DEFAULT_DEX_APPROVED_ADDRESSES_CACHE_SIZE),
@@ -218,8 +238,13 @@ impl Okx {
     ) -> Result<(dto::SwapResponse, eth::ContractAddress), Error> {
         let swap_future = async {
             let swap_request = self.defaults.clone().with_domain(order, slippage);
-            self.send_get_request(&self.sell_orders_endpoint, "swap", &swap_request)
-                .await
+            self.send_get_request(
+                &self.sell_orders_endpoint,
+                &self.sell_orders_signature_base_url,
+                "swap",
+                &swap_request,
+            )
+            .await
         };
 
         let approve_future = async {
@@ -232,6 +257,7 @@ impl Okx {
             let approve_tx: dto::ApproveTransactionResponse = self
                 .send_get_request(
                     &self.sell_orders_endpoint,
+                    &self.sell_orders_signature_base_url,
                     "approve-transaction",
                     &approve_request,
                 )
@@ -261,10 +287,15 @@ impl Okx {
             .as_ref()
             .ok_or(Error::OrderNotSupported)?;
 
+        let signature_base_url = self
+            .buy_orders_signature_base_url
+            .as_ref()
+            .ok_or(Error::OrderNotSupported)?;
+
         let swap_request_v6 = self.defaults.clone().with_domain(order, slippage);
         let swap_request_v5: dto::SwapRequestV5 = (&swap_request_v6).into();
         let swap_response: dto::SwapResponse = self
-            .send_get_request(endpoint, "swap", &swap_request_v5)
+            .send_get_request(endpoint, signature_base_url, "swap", &swap_request_v5)
             .await?;
 
         let approve_future = async {
@@ -276,7 +307,12 @@ impl Okx {
             let approve_request_v5: dto::ApproveTransactionRequestV5 = (&approve_request).into();
 
             let approve_tx: dto::ApproveTransactionResponse = self
-                .send_get_request(endpoint, "approve-transaction", &approve_request_v5)
+                .send_get_request(
+                    endpoint,
+                    signature_base_url,
+                    "approve-transaction",
+                    &approve_request_v5,
+                )
                 .await?;
 
             Ok(eth::ContractAddress(approve_tx.dex_contract_address))
@@ -314,12 +350,13 @@ impl Okx {
     fn generate_signature(
         &self,
         request: &reqwest::Request,
+        signature_base_url: &reqwest::Url,
         timestamp: &str,
     ) -> Result<String, Error> {
         let mut data = String::new();
         data.push_str(timestamp);
         data.push_str(request.method().as_str());
-        data.push_str(request.url().path());
+        data.push_str(signature_base_url.path());
         data.push('?');
         data.push_str(request.url().query().ok_or(Error::SignRequestFailed)?);
 
@@ -348,6 +385,7 @@ impl Okx {
     async fn send_get_request<T, U>(
         &self,
         base_url: &reqwest::Url,
+        signature_base_url: &reqwest::Url,
         endpoint: &str,
         query: &T,
     ) -> Result<U, Error>
@@ -371,10 +409,14 @@ impl Okx {
             .build()
             .map_err(|_| Error::RequestBuildFailed)?;
 
+        let signature_url = signature_base_url
+            .join(endpoint)
+            .map_err(|_| Error::RequestBuildFailed)?;
+
         let timestamp = &chrono::Utc::now()
             .to_rfc3339_opts(SecondsFormat::Millis, true)
             .to_string();
-        let signature = self.generate_signature(&request, timestamp)?;
+        let signature = self.generate_signature(&request, &signature_url, timestamp)?;
 
         request_builder = request_builder.header(
             "OK-ACCESS-TIMESTAMP",

--- a/src/run.rs
+++ b/src/run.rs
@@ -78,9 +78,9 @@ async fn run_with(args: cli::Args, bind: Option<oneshot::Sender<SocketAddr>>) {
         cli::Command::Okx { config } => {
             let config = config::dex::okx::file::load(&config).await;
             Solver::Dex(solver::Dex::new(
-                dex::Dex::Okx(
+                dex::Dex::Okx(Box::new(
                     dex::okx::Okx::try_new(config.okx).expect("invalid OKX configuration"),
-                ),
+                )),
                 config.base.clone(),
             ))
         }

--- a/src/tests/okx/api_calls.rs
+++ b/src/tests/okx/api_calls.rs
@@ -18,6 +18,8 @@ async fn swap_sell_regular() {
     let okx_config = okx_dex::Config {
         sell_orders_endpoint: reqwest::Url::parse(okx_dex::DEFAULT_SELL_ORDERS_ENDPOINT).unwrap(),
         buy_orders_endpoint: None,
+        sell_orders_signature_base_url: None,
+        buy_orders_signature_base_url: None,
         chain_id: crate::domain::eth::ChainId::Mainnet,
         okx_credentials: okx_dex::OkxCredentialsConfig {
             project_id: env::var("OKX_PROJECT_ID").unwrap(),
@@ -61,6 +63,8 @@ async fn swap_buy_disabled() {
     let okx_config = okx_dex::Config {
         sell_orders_endpoint: reqwest::Url::parse(okx_dex::DEFAULT_SELL_ORDERS_ENDPOINT).unwrap(),
         buy_orders_endpoint: None,
+        sell_orders_signature_base_url: None,
+        buy_orders_signature_base_url: None,
         chain_id: crate::domain::eth::ChainId::Mainnet,
         okx_credentials: okx_dex::OkxCredentialsConfig {
             project_id: String::new(),
@@ -102,6 +106,8 @@ async fn swap_buy_enabled() {
     let okx_config = okx_dex::Config {
         sell_orders_endpoint: reqwest::Url::parse(okx_dex::DEFAULT_SELL_ORDERS_ENDPOINT).unwrap(),
         buy_orders_endpoint: Some(reqwest::Url::parse(DEFAULT_BUY_ORDERS_ENDPOINT).unwrap()),
+        sell_orders_signature_base_url: None,
+        buy_orders_signature_base_url: None,
         chain_id: crate::domain::eth::ChainId::Mainnet,
         okx_credentials: okx_dex::OkxCredentialsConfig {
             project_id: env::var("OKX_PROJECT_ID").unwrap(),
@@ -150,6 +156,8 @@ async fn swap_api_error() {
     let okx_config = okx_dex::Config {
         sell_orders_endpoint: reqwest::Url::parse(okx_dex::DEFAULT_SELL_ORDERS_ENDPOINT).unwrap(),
         buy_orders_endpoint: None,
+        sell_orders_signature_base_url: None,
+        buy_orders_signature_base_url: None,
         chain_id: crate::domain::eth::ChainId::Mainnet,
         okx_credentials: okx_dex::OkxCredentialsConfig {
             project_id: env::var("OKX_PROJECT_ID").unwrap(),
@@ -192,6 +200,8 @@ async fn swap_sell_insufficient_liquidity() {
     let okx_config = okx_dex::Config {
         sell_orders_endpoint: reqwest::Url::parse(okx_dex::DEFAULT_SELL_ORDERS_ENDPOINT).unwrap(),
         buy_orders_endpoint: None,
+        sell_orders_signature_base_url: None,
+        buy_orders_signature_base_url: None,
         chain_id: crate::domain::eth::ChainId::Mainnet,
         okx_credentials: okx_dex::OkxCredentialsConfig {
             project_id: env::var("OKX_PROJECT_ID").unwrap(),
@@ -234,6 +244,8 @@ async fn swap_buy_insufficient_liquidity() {
     let okx_config = okx_dex::Config {
         sell_orders_endpoint: reqwest::Url::parse(okx_dex::DEFAULT_SELL_ORDERS_ENDPOINT).unwrap(),
         buy_orders_endpoint: Some(reqwest::Url::parse(DEFAULT_BUY_ORDERS_ENDPOINT).unwrap()),
+        sell_orders_signature_base_url: None,
+        buy_orders_signature_base_url: None,
         chain_id: crate::domain::eth::ChainId::Mainnet,
         okx_credentials: okx_dex::OkxCredentialsConfig {
             project_id: env::var("OKX_PROJECT_ID").unwrap(),


### PR DESCRIPTION
## Problem

When routing OKX API requests through an egress proxy, the request signature generation breaks. OKX's API signature is generated from the request URL path, but when using a proxy, the actual request URL path differs from the original OKX API URL path that should be used for signature generation.

For example:
- Requests are sent to: `https://proxy.example.com/cached/okx/v6/mainnet/solve/swap`
- But signature must use: `https://web3.okx.com/api/v6/dex/aggregator/swap`

This causes all requests through the proxy to fail with authentication errors.

## Solution

Add optional `sell-orders-signature-base-url` and `buy-orders-signature-base-url` configuration fields. When specified, these URLs are used exclusively for generating the request signature, while the actual HTTP requests continue to use the configured endpoint URLs.

This approach:
- Maintains backward compatibility (if not specified, uses endpoint URLs)
- Keeps the configuration clear and explicit
- Only requires configuration when using a proxy

## Changes

- Add optional signature base URL fields to OKX config
- Update signature generation to use signature base URLs when provided
- Box the `Okx` enum variant to address clippy warning about large enum size
- Update example config with proxy usage documentation
- Update all tests to include new optional fields
