### PR TITLE
Bump actions/checkout to v4 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0 # Fetch all history for all branches and tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
           fetch-depth: 0 # Fetch all history for all branches and tags


### PR DESCRIPTION
# Description
The Weekly Release workflow has been failing every Monday since 2026-04-13 with `fatal: could not read Username for 'https://github.com': terminal prompts disabled` during the checkout step. `actions/checkout@v2` (released in 2020) is broken on current GitHub runners when a custom `token:` is passed: the auth header is configured but never propagated to `git fetch`. The other workflows using v2 keep working because they do not pass a custom token.

# Changes
- Bump `actions/checkout` from `v2` to `v4` in `.github/workflows/release.yml`

# How to test
After merge, trigger the Weekly Release workflow manually via the Actions tab and confirm the checkout step succeeds.